### PR TITLE
GUVNOR-1476 fixed error condition handling in DSLLoader

### DIFF
--- a/guvnor-webapp/src/main/java/org/drools/guvnor/server/builder/DSLLoader.java
+++ b/guvnor-webapp/src/main/java/org/drools/guvnor/server/builder/DSLLoader.java
@@ -59,8 +59,16 @@ public class DSLLoader {
 
     private static void logErrors(BRMSPackageBuilder.DSLErrorEvent dslErrorEvent, AssetItem assetItem, DSLTokenizedMappingFile file) {
         for (Object o : file.getErrors()) {
-            DSLMappingParseException dslMappingParseException = (DSLMappingParseException) o;
-            dslErrorEvent.recordError(assetItem, "Line " + dslMappingParseException.getLine() + " : " + dslMappingParseException.getMessage());
+        	
+        	if(o instanceof DSLMappingParseException){
+	            DSLMappingParseException dslMappingParseException = (DSLMappingParseException) o;
+	            dslErrorEvent.recordError(assetItem, "Line " + dslMappingParseException.getLine() + " : " + dslMappingParseException.getMessage());
+        	}else if(o instanceof Exception){
+        		Exception excp = (Exception)o;
+        		dslErrorEvent.recordError(assetItem, "Exception "+ excp.getClass()+" "+ excp.getMessage()+" "+excp.getCause());
+        	}else{
+        		dslErrorEvent.recordError(assetItem, "Uncategorized error "+o);
+        	}
         }
     }
 }


### PR DESCRIPTION
Added type safe checking to error handling in DSLLoader in Guvnor so that parsing errors don't result in Guvnor errors when saving DSL resources
