### PR TITLE
GUVNOR-1584: Standalone Rule Editor: Bug when editing multiple BRL rules

### DIFF
--- a/guvnor-webapp/src/main/java/org/drools/guvnor/server/standalonededitor/BRLRuleAssetProvider.java
+++ b/guvnor-webapp/src/main/java/org/drools/guvnor/server/standalonededitor/BRLRuleAssetProvider.java
@@ -27,6 +27,7 @@ import org.drools.ide.common.server.util.BRXMLPersistence;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * BRL -> RuleAsset converter used by standalone editor.
@@ -83,7 +84,7 @@ public class BRLRuleAssetProvider
     private RuleAsset createAsset(RuleModel ruleModel) {
         RuleAsset asset = new RuleAsset();
 
-        asset.setUuid("mock");
+        asset.setUuid("mock-"+UUID.randomUUID().toString());
         asset.setContent(ruleModel);
         asset.setName(ruleModel.name);
         asset.setMetaData(createMetaData());


### PR DESCRIPTION
```
- All the assets were created with the same UUID. This was causing the confusion in the editor.
```
