### PR TITLE
Guvnor assembly descriptor for JBoss AS 7

### DIFF
--- a/guvnor-distribution-wars/pom.xml
+++ b/guvnor-distribution-wars/pom.xml
@@ -29,16 +29,35 @@
             <goals>
               <goal>single</goal>
             </goals>
+	        <configuration>
+	          <finalName>guvnor-${pom.version}</finalName>
+	          <descriptors>
+	            <descriptor>src/main/assembly/assembly-guvnor-jboss-as-5_1.xml</descriptor>
+	            <descriptor>src/main/assembly/assembly-guvnor-jboss-as-6_0.xml</descriptor>
+	            <descriptor>src/main/assembly/assembly-guvnor-tomcat-6_0.xml</descriptor>
+	          </descriptors>
+	        </configuration>
+          </execution>
+          <execution>
+          	<id>jboss-as-7</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+	        <configuration>
+	          <finalName>guvnor-${pom.version}</finalName>
+	          <descriptors>
+	            <descriptor>src/main/assembly/assembly-guvnor-jboss-as-7_0.xml</descriptor>
+	          </descriptors>
+	          <archive>
+	              <!-- Add dependency to jbossws-cxf module in JBoss AS 7 -->
+	              <manifestEntries>
+	                 <Dependencies>org.jboss.ws.cxf.jbossws-cxf-client services export</Dependencies>
+	              </manifestEntries>  
+	          </archive>
+	        </configuration>
           </execution>
         </executions>
-        <configuration>
-          <finalName>guvnor-${pom.version}</finalName>
-          <descriptors>
-            <descriptor>src/main/assembly/assembly-guvnor-jboss-as-5_1.xml</descriptor>
-            <descriptor>src/main/assembly/assembly-guvnor-jboss-as-6_0.xml</descriptor>
-            <descriptor>src/main/assembly/assembly-guvnor-tomcat-6_0.xml</descriptor>
-          </descriptors>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/guvnor-distribution-wars/src/main/assembly/assembly-guvnor-jboss-as-7_0.xml
+++ b/guvnor-distribution-wars/src/main/assembly/assembly-guvnor-jboss-as-7_0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <id>jboss-as-7.0</id>
+  <formats>
+    <format>war</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <dependencySets>
+    <dependencySet>
+      <includes>
+        <include>org.drools:guvnor-webapp:war</include>
+      </includes>
+      <outputDirectory>.</outputDirectory>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <!-- Exclude all CXF jars except cxf-rt-frontend-jaxrs-->
+          <exclude>WEB-INF/lib/cxf-api-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-common-schemas-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-common-utilities-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-rt-bindings-xml-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-rt-core-*.jar</exclude>
+          <exclude>WEB-INF/lib/cxf-rt-transports-http-*.jar</exclude> 
+        </excludes>
+      </unpackOptions>
+      <useStrictFiltering>true</useStrictFiltering>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>


### PR DESCRIPTION
I noticed Guvnor was missing a WAR for JBoss AS 7 so I created an assembly descriptor. Hope you find this useful. I have tested the WAR on JBoss AS 7.0.1.Final in standalone mode. 

Regards,
Mattias Nilsson Grip
