### PR TITLE
Process Designer Dimension Problems:

### DIFF
--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/client/asseteditor/RuleViewer.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/client/asseteditor/RuleViewer.java
@@ -106,10 +106,10 @@ public class RuleViewer extends GuvnorEditor {
                 eventBus);
 
         // for designer we need to give it more playing room
-        if ( editor.getClass().getName().equals( "org.drools.guvnor.client.processeditor.BusinessProcessEditor" ) ) {
+        if (editor instanceof BusinessProcessEditor) {  
             if ( this.ruleViewerSettings.isStandalone() ) {
                 // standalone bigger dimensions"
-                editor.setWidth( "1600px" );
+                editor.setWidth( "100%" );
                 editor.setHeight( "1000px" );
             } else {
                 // normal dimensions inside guvnor


### PR DESCRIPTION
- BusinessProcessEditor was moved from org.drools.guvnor.client.processeditor. It is better to use instanceof instead of the hardcoded name
- Do not use a fixed width: a 100% width is better
