### PR TITLE
GUVNOR-1771: Active working-sets were removed when SCE was re-loadedActi...

### DIFF
--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/client/rpc/StandaloneEditorInvocationParameters.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/client/rpc/StandaloneEditorInvocationParameters.java
@@ -39,6 +39,9 @@ public class StandaloneEditorInvocationParameters implements Serializable {
     private boolean hideAttributes;
     private String clientName;
 
+    public StandaloneEditorInvocationParameters() {
+    }
+
     public RuleAsset[] getAssetsToBeEdited() {
         return assetsToBeEdited;
     }

--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/NewAssetWizard.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/NewAssetWizard.java
@@ -572,7 +572,7 @@ public class NewAssetWizard extends FormStylePopup {
     public void flushSuggestionCompletionCache() {
         if ( AssetFormats.isPackageDependency( format ) ) {
             LoadingPopup.showMessage( constants.RefreshingContentAssistance() );
-            SuggestionCompletionCache.getInstance().refreshPackage( importedPackageSelector.getSelectedPackage(),
+            SuggestionCompletionCache.getInstance().loadPackage( importedPackageSelector.getSelectedPackage(),
                                                                     new Command() {
                                                                         public void execute() {
                                                                             //Some assets depend on the SuggestionCompletionEngine. This event is to notify them that the 

--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/widgets/drools/toolbar/AssetEditorActionToolbar.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/widgets/drools/toolbar/AssetEditorActionToolbar.java
@@ -559,7 +559,7 @@ public class AssetEditorActionToolbar extends Composite {
     public void flushSuggestionCompletionCache(final String packageName) {
         if ( AssetFormats.isPackageDependency( this.asset.getFormat() ) ) {
             LoadingPopup.showMessage( constants.RefreshingContentAssistance() );
-            SuggestionCompletionCache.getInstance().refreshPackage( packageName,
+            SuggestionCompletionCache.getInstance().loadPackage( packageName,
                     new Command() {
                         public void execute() {
                             //Some assets depend on the SuggestionCompletionEngine. This event is to notify them that the 

--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/widgets/drools/toolbar/PackageEditorActionToolbar.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/widgets/drools/toolbar/PackageEditorActionToolbar.java
@@ -381,7 +381,7 @@ public class PackageEditorActionToolbar extends Composite {
                         refreshCommand.execute();
                         LoadingPopup.showMessage( constants.PackageConfigurationUpdatedSuccessfullyRefreshingContentCache() );
 
-                        SuggestionCompletionCache.getInstance().refreshPackage( packageConfigData.getName(),
+                        SuggestionCompletionCache.getInstance().loadPackage( packageConfigData.getName(),
                                 new Command() {
                                     public void execute() {
                                         if ( refresh != null ) {

--- a/guvnor-webapp-drools/src/test/java/org/drools/guvnor/client/moduleeditor/drools/SuggestionCompletionCacheTest.java
+++ b/guvnor-webapp-drools/src/test/java/org/drools/guvnor/client/moduleeditor/drools/SuggestionCompletionCacheTest.java
@@ -57,7 +57,7 @@ public class SuggestionCompletionCacheTest {
             }
         };
 
-        cache.refreshPackage( "xyz", new Command() {
+        cache.loadPackage( "xyz", new Command() {
             public void execute() {
             }
         });
@@ -66,7 +66,7 @@ public class SuggestionCompletionCacheTest {
         SuggestionCompletionEngine eng = new SuggestionCompletionEngine();
         cache.cache.put( "foo",  eng);
 
-        cache.refreshPackage( "foo", new Command() {
+        cache.loadPackage( "foo", new Command() {
 
             public void execute() {
                 executed = true;
@@ -78,7 +78,7 @@ public class SuggestionCompletionCacheTest {
 
         assertNotNull(cache.getEngineFromCache( "foo" ));
 
-        cache.refreshPackage( "foo", new Command() {
+        cache.loadPackage( "foo", new Command() {
 
             public void execute() {
 


### PR DESCRIPTION
...ve Working-Sets are removed whenever RefreshModuleDataModelEvent is fired

SuggestionCompletionCache:
    - Code cleanup
    - refreshPackage() now removes any active working-set
    - loadPackage() now reloads a package maintaining any active working-set
WorkingSetManager:
    - Code cleanup
StandaloneEditorInvocationParameters:
    - Added empty constructor to avoid GWT Serialization errors
