### PR TITLE
GUVNOR-1792 Guided Rule Editor doesn't list no-setter-fields in LHS if a...

### DIFF
--- a/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/server/util/SuggestionCompletionEngineBuilder.java
+++ b/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/server/util/SuggestionCompletionEngineBuilder.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,8 +111,20 @@ public class SuggestionCompletionEngineBuilder {
      */
     public void addFieldsForType(final String type,
                                  final String[] fields) {
-        this.fieldsForType.put( type,
-                                fields );
+        String[] oldFields = this.fieldsForType.get(type);
+        if ( oldFields != null ) {
+            List<String> mergedFields = new ArrayList<String>(Arrays.asList(oldFields));
+            for ( String field : fields ) {
+                if (!mergedFields.contains(field)) {
+                    mergedFields.add(field);
+                }
+            }
+            this.fieldsForType.put( type,
+                    mergedFields.toArray(new String[mergedFields.size()]) );
+        } else {
+            this.fieldsForType.put( type,
+                                    fields );
+        }
     }
 
     /**

--- a/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/server/rules/ReadOnlyFact.java
+++ b/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/server/rules/ReadOnlyFact.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.ide.common.server.rules;
+
+public class ReadOnlyFact {
+
+    private String name;
+
+    public ReadOnlyFact() {
+
+    }
+
+    public ReadOnlyFact(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/server/rules/SuggestionCompletionLoaderTest.java
+++ b/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/server/rules/SuggestionCompletionLoaderTest.java
@@ -681,4 +681,50 @@ public class SuggestionCompletionLoaderTest {
         return -1;
     }
 
+    @Test
+    public void testReadOnlyFieldWithAnnotation() throws Exception {
+        // GUVNOR-1792
+        SuggestionCompletionLoader loader = new SuggestionCompletionLoader();
+
+        String header = "";
+        header += "package foo \n import org.drools.ide.common.server.rules.ReadOnlyFact\n";
+
+        header += "declare ReadOnlyFact\n";
+        header += "@role( event )\n";
+        header += "end\n";
+
+        SuggestionCompletionEngine eng = loader.getSuggestionEngine( header,
+                                                                     new ArrayList(),
+                                                                     new ArrayList() );
+        assertNotNull( eng );
+
+        assertEquals( SuggestionCompletionEngine.TYPE_STRING,
+                      eng.getFieldType( "ReadOnlyFact",
+                                        "name" ) );
+    }
+
+    @Test
+    public void testReadOnlyFieldWithAnnotationAndField() throws Exception {
+        SuggestionCompletionLoader loader = new SuggestionCompletionLoader();
+
+        String header = "";
+        header += "package foo \n import org.drools.ide.common.server.rules.ReadOnlyFact\n";
+
+        header += "declare ReadOnlyFact\n";
+        header += "@role( event )\n";
+        header += "age: Integer\n";
+        header += "end\n";
+
+        SuggestionCompletionEngine eng = loader.getSuggestionEngine( header,
+                                                                     new ArrayList(),
+                                                                     new ArrayList() );
+        assertNotNull( eng );
+
+        assertEquals( SuggestionCompletionEngine.TYPE_STRING,
+                      eng.getFieldType( "ReadOnlyFact",
+                                        "name" ) );
+        assertEquals( SuggestionCompletionEngine.TYPE_NUMERIC,
+                      eng.getFieldType( "ReadOnlyFact",
+                                        "age" ) );
+    }
 }


### PR DESCRIPTION
Changed SuggestionCompletionEngineBuilder.addFieldsForType() to merge fields if an entry for the type already exists.
Also added 2 test cases. One is read-only Pojo + annotation (= the scenario described in GUVNOR-1792). The other is read-only Pojo + annotation + declared field.
I also tested with GUI.
