### PR TITLE
GUVNOR-1811: Guided Editor: Field Bindings are NOT being shown in Expression Builder 

### DIFF
--- a/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/ExpressionFieldVariable.java
+++ b/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/ExpressionFieldVariable.java
@@ -19,18 +19,17 @@ package org.drools.ide.common.client.modeldriven.brl;
 import org.drools.ide.common.client.modeldriven.SuggestionCompletionEngine;
 
 /**
- * This expression represent a bound field. Right now it only acts as a Text
- * expression
+ * This expression represent a bound field. 
  */
 public class ExpressionFieldVariable extends ExpressionText {
 
     protected ExpressionFieldVariable() {
     }
 
-    public ExpressionFieldVariable(String name) {
+    public ExpressionFieldVariable(String name, String type) {
         super( name,
-               "java.lang.String",
-               SuggestionCompletionEngine.TYPE_FINAL_OBJECT );
+               type,
+               type);
     }
 
     @Override

--- a/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/RuleModel.java
+++ b/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/RuleModel.java
@@ -242,10 +242,11 @@ public class RuleModel
     }
 
     /**
-     * This will get a list of all bound variables, including bound fields..
+     * This will get a list of all LHS bound variables, including bound fields..
      */
-    public List<String> getAllVariables() {
+    public List<String> getAllLHSVariables(){
         List<String> result = new ArrayList<String>();
+        
         for ( int i = 0; i < this.lhs.length; i++ ) {
             IPattern pat = this.lhs[i];
             if ( pat instanceof FactPattern ) {
@@ -273,7 +274,16 @@ public class RuleModel
                 }
             }
         }
-
+        
+        return result;
+    }
+    
+    /**
+     * This will get a list of all RHS bound variables.
+     */
+    public List<String> getAllRHSVariables() {
+        List<String> result = new ArrayList<String>();
+        
         for ( int i = 0; i < this.rhs.length; i++ ) {
             IAction pat = this.rhs[i];
             if ( pat instanceof ActionInsertFact ) {
@@ -283,6 +293,18 @@ public class RuleModel
                 }
             }
         }
+        
+        return result;
+    }
+    
+    /**
+     * This will get a list of all bound variables (LHS and RHS), including bound fields..
+     */
+    public List<String> getAllVariables() {
+        List<String> result = new ArrayList<String>();
+        
+        result.addAll(this.getAllLHSVariables());
+        result.addAll(this.getAllRHSVariables());
 
         return result;
     }

--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/modeldriven/ui/ExpressionBuilder.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/modeldriven/ui/ExpressionBuilder.java
@@ -55,6 +55,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
+import org.drools.ide.common.client.modeldriven.brl.FieldConstraint;
 
 public class ExpressionBuilder extends RuleModellerWidget
     implements
@@ -149,7 +150,7 @@ public class ExpressionBuilder extends RuleModellerWidget
                                 GLOBAL_VARIABLE_VALUE_PREFIX + "." + gv );
         }
 
-        for ( String v : getRuleModel().getLHSBoundFacts() ) {
+        for ( String v : getRuleModel().getAllLHSVariables() ) {
             startPoint.addItem( v,
                                 VARIABLE_VALUE_PREFIX + "." + v );
         }
@@ -189,8 +190,10 @@ public class ExpressionBuilder extends RuleModellerWidget
             if ( fact != null ) {
                 variable = new ExpressionVariable( fact );
             } else {
-                //TODO {baunax} fix it!!! to make recursive
-                variable = new ExpressionFieldVariable( attrib );
+                //if the variable is not bound to a Fact Pattern then it must
+                //be boubd to a Field
+                String lhsBindingType = getRuleModel().getLHSBindingType(attrib);
+                variable = new ExpressionFieldVariable(attrib, lhsBindingType );
             }
             expression.appendPart( variable );
 


### PR DESCRIPTION
ExpressionFieldVariable:
        - Field Variables are not longer treated as String. Now they also have its real type.

ExpressionBuilder:
    - Populate initial drop-down also with Field bound variables
    - Create ExpressionFieldVariables with their propper type

RuleModel:
    - getAllVariables() is now implemented using 2 different methods, getAllLHSVariables() and getAllRHSVariables(), that can be separately invoked
