### PR TITLE
Guided Rule Editor doesn't show a popup for field name binding in case o...

### DIFF
--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/modeldriven/ui/FactPatternWidget.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/client/asseteditor/drools/modeldriven/ui/FactPatternWidget.java
@@ -90,19 +90,6 @@ public class FactPatternWidget extends RuleModellerWidget {
               null );
     }
 
-    public FactPatternWidget(RuleModeller mod,
-                             EventBus eventBus,
-                             IPattern p,
-                             boolean isAll0WithLabel,
-                             boolean canBind) {
-        this( mod,
-              eventBus,
-              p,
-              isAll0WithLabel,
-              canBind,
-              null );
-    }
-
     /**
      * Creates a new FactPatternWidget
      * 


### PR DESCRIPTION
org.drools.guvnor.client.asseteditor.drools.modeldriven.ui.FactPatternWidget has 2 similar constructors (Look at the 5th argument type!):

```
public FactPatternWidget(RuleModeller mod,
                         EventBus eventBus,
                         IPattern p,
                         boolean isAll0WithLabel,
                         boolean canBind) {
    this( mod,
          eventBus,
          p,
          isAll0WithLabel,
          canBind,
          null );
}

public FactPatternWidget(RuleModeller ruleModeller,
                         EventBus eventBus,
                         IPattern pattern,
                         boolean canBind,
                         Boolean readOnly) {
    this( ruleModeller,
          eventBus,
          pattern,
          false,
          canBind,
          readOnly );
}
```

The former constructor is only used by org.drools.guvnor.client.asseteditor.drools.modeldriven.ui.FromCompositeFactPatternWidget.createFactPatternWidget()

```
private Widget createFactPatternWidget(FactPattern fact) {
    FactPatternWidget factPatternWidget;
    if ( this.readOnly ) {
        //creates a new read-only FactPatternWidget
        factPatternWidget = new FactPatternWidget( this.getModeller(),
                                                   this.getEventBus(),
                                                   fact,
                                                   false,
                                                   true );
        //this.layout.setWidget( 0, 0, factPatternWidget );
        return factPatternWidget;
    } else {
        factPatternWidget = new FactPatternWidget( this.getModeller(),
                                                   this.getEventBus(),
                                                   fact,
                                                   true,
                                                   false );
```

I believe that createFactPatternWidget() wants to call the latter constructor. This is the root cause of this issue.
So deleting the former constructor is the cleanest way to fix this issue. You don't have to fix createFactPatternWidget() thanks to autoboxing.

Could you review it?

Thanks!
