### PR TITLE
GUVNOR-1831: Guided Rule Editor: Expression editor doesn't list bound va...

### DIFF
--- a/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/RuleModel.java
+++ b/droolsjbpm-ide-common/src/main/java/org/drools/ide/common/client/modeldriven/brl/RuleModel.java
@@ -54,8 +54,12 @@ public class RuleModel
         }
         final List<String> list = new ArrayList<String>();
         for ( int i = 0; i < this.lhs.length; i++ ) {
-            if ( this.lhs[i] instanceof FactPattern ) {
-                final FactPattern p = (FactPattern) this.lhs[i];
+            IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
+            if ( pat instanceof FactPattern ) {
+                final FactPattern p = (FactPattern) pat;
                 if ( p.getBoundName() != null ) {
                     list.add( p.getBoundName() );
                 }
@@ -76,8 +80,12 @@ public class RuleModel
             return null;
         }
         for ( int i = 0; i < this.lhs.length; i++ ) {
-            if ( this.lhs[i] instanceof FactPattern ) {
-                final FactPattern p = (FactPattern) this.lhs[i];
+            IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
+            if ( pat instanceof FactPattern ) {
+                final FactPattern p = (FactPattern) pat;
                 if ( p.getBoundName() != null && var.equals( p.getBoundName() ) ) {
                     return p;
                 }
@@ -98,8 +106,12 @@ public class RuleModel
             return null;
         }
         for ( int i = 0; i < this.lhs.length; i++ ) {
-            if ( this.lhs[i] instanceof FactPattern ) {
-                final FactPattern p = (FactPattern) this.lhs[i];
+            IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
+            if ( pat instanceof FactPattern ) {
+                final FactPattern p = (FactPattern) pat;
                 for ( int j = 0; j < p.getFieldConstraints().length; j++ ) {
                     FieldConstraint fc = p.getFieldConstraints()[j];
                     List<String> fieldBindings = getFieldBinding( fc );
@@ -123,8 +135,12 @@ public class RuleModel
             return null;
         }
         for ( int i = 0; i < this.lhs.length; i++ ) {
-            if ( this.lhs[i] instanceof FactPattern ) {
-                final FactPattern p = (FactPattern) this.lhs[i];
+            IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
+            if ( pat instanceof FactPattern ) {
+                final FactPattern p = (FactPattern) pat;
                 if ( p.isBound() && var.equals( p.getBoundName() ) ) {
                     return p.getFactType();
                 }
@@ -224,8 +240,12 @@ public class RuleModel
             return null;
         }
         for ( int i = 0; i < this.lhs.length; i++ ) {
-            if ( this.lhs[i] instanceof FactPattern ) {
-                final FactPattern p = (FactPattern) this.lhs[i];
+            IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
+            if ( pat instanceof FactPattern ) {
+                final FactPattern p = (FactPattern) pat;
                 if ( p.getBoundName() != null && var.equals( p.getBoundName() ) ) {
                     return p;
                 }
@@ -249,6 +269,9 @@ public class RuleModel
         
         for ( int i = 0; i < this.lhs.length; i++ ) {
             IPattern pat = this.lhs[i];
+            if ( pat instanceof FromCompositeFactPattern ) {
+                pat = ((FromCompositeFactPattern) pat).getFactPattern();
+            }
             if ( pat instanceof FactPattern ) {
                 FactPattern fact = (FactPattern) pat;
                 if ( fact.isBound() ) {
@@ -353,8 +376,12 @@ public class RuleModel
                 newList[newIdx] = this.lhs[i];
                 newIdx++;
             } else {
-                if ( this.lhs[i] instanceof FactPattern ) {
-                    final FactPattern p = (FactPattern) this.lhs[i];
+                IPattern pat = this.lhs[i];
+                if ( pat instanceof FromCompositeFactPattern ) {
+                    pat = ((FromCompositeFactPattern) pat).getFactPattern();
+                }
+                if ( pat instanceof FactPattern ) {
+                    final FactPattern p = (FactPattern) pat;
                     if ( p.getBoundName() != null && isBoundFactUsed( p.getBoundName() ) ) {
                         return false;
                     }

--- a/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/modeldriven/RuleModelTest.java
+++ b/droolsjbpm-ide-common/src/test/java/org/drools/ide/common/modeldriven/RuleModelTest.java
@@ -35,6 +35,7 @@ import org.drools.ide.common.client.modeldriven.brl.DSLSentence;
 import org.drools.ide.common.client.modeldriven.brl.ExpressionField;
 import org.drools.ide.common.client.modeldriven.brl.FactPattern;
 import org.drools.ide.common.client.modeldriven.brl.FieldConstraint;
+import org.drools.ide.common.client.modeldriven.brl.FromCompositeFactPattern;
 import org.drools.ide.common.client.modeldriven.brl.IAction;
 import org.drools.ide.common.client.modeldriven.brl.IPattern;
 import org.drools.ide.common.client.modeldriven.brl.RuleAttribute;
@@ -909,5 +910,50 @@ public class RuleModelTest {
         assertEquals( c,
                       model.rhs[6] );
 
+    }
+
+    @Test
+    public void testBoundFromCompositeFactFinder() {
+        final RuleModel model = new RuleModel();
+
+        model.lhs = new IPattern[1];
+
+        final FromCompositeFactPattern fcfp = new FromCompositeFactPattern( );
+        final FactPattern x = new FactPattern( "Car" );
+        x.setBoundName( "x" );
+        final SingleFieldConstraint a = new SingleFieldConstraint( "name" );
+        a.setFieldBinding( "a" );
+        a.setFieldType( "String" );
+        x.addConstraint( a );
+        fcfp.setFactPattern(x);
+
+        model.lhs[0] = fcfp;
+
+        assertEquals( x, model.getLHSBoundFact( "x" ) );
+
+        assertEquals( 1, model.getLHSBoundFacts().size() );
+        assertEquals( "x", model.getLHSBoundFacts().get(0) );
+
+        assertEquals( a, model.getLHSBoundField( "a" ) );
+
+        assertEquals( "Car", model.getLHSBindingType( "x" ) );
+        assertEquals( "String", model.getLHSBindingType( "a" ) );
+
+        assertEquals( x, model.getLHSParentFactPatternForBinding( "a" ) );
+
+        assertEquals( 2, model.getAllLHSVariables().size() );
+        assertTrue( model.getAllLHSVariables().contains("x") );
+        assertTrue( model.getAllLHSVariables().contains("a") );
+
+        model.rhs = new IAction[1];
+        final ActionSetField set = new ActionSetField();
+        set.variable = "x";
+        model.rhs[0] = set;
+
+        assertTrue( model.isBoundFactUsed( "x" ) );
+
+        assertEquals( 1,  model.lhs.length );
+        assertFalse( model.removeLhsItem( 0 ) );
+        assertEquals( 1,  model.lhs.length );
     }
 }


### PR DESCRIPTION
GUVNOR-1831: Guided Rule Editor: Expression editor doesn't list bound variable names of 'From' fact pattern
https://issues.jboss.org/browse/GUVNOR-1831

org.drools.ide.common.client.modeldriven.brl.RuleModel.getAllLHSVariables() and other getLHSXXX methods overlook the case where FromCompositeFactPattern (and its sub classes) is used in LHS.
