### PR TITLE
Add Zanata configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
             <configuration>
                 <!-- Process sub-modules separately, sharing parent config -->
                 <enableModules>true</enableModules>
-                <projectConfig>${session.executionRootDirectory}/zanata.xml</projectConfig>
+                <projectConfig>${session.executionRootDirectory}/src/main/zanata/zanata.xml</projectConfig>
                 <srcDir>src/main/java</srcDir>
                 <transDir>src/main/java/</transDir>
                 <includes>**/Constants.properties,**/ConstantsCore.properties</includes>

--- a/src/main/zanata/zanata.xml
+++ b/src/main/zanata/zanata.xml
@@ -3,6 +3,7 @@
   <url>https://translate.jboss.org/</url>
   <project>Guvnor</project>
   <project-version>5.5.0</project-version>
+  <project-type>utf8properties</project-type>
 
   <locales>
     <locale map-from="es_ES">es</locale>


### PR DESCRIPTION
In the main POM file added the zanata maven plugin definition and configuration.
Added zanata.xml which contains locale and server configuration.

To push source documents:
   mvn zanata:push -Dfull -Dngsoa -Dngsoafull -Dbpm

To push source documents and translations:
mvn zanata:push -Dfull -Dngsoa -Dngsoafull -Dbpm -Dzanata.pushTrans

To fetch the latest translations:
mvn zanata:pull -Dfull -Dngsoa -Dngsoafull -Dbpm

To specify zanata credentials (user name, API key), the maven plugin accepts the following parameters:
-Dzanata.key=<KEY> -Dzanata.username=<USERNAME>

Alternatively, the plugin will look for a zanata.ini file in the user's ~/.config directory. Visit  the 'Profile' section in Zanata for the format contents of this file.
