### PR TITLE
GUVNOR-1906 : ActionsAPIServlet does nothing and returns 'OK'

### DIFF
--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/files/ActionsAPI.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/files/ActionsAPI.java
@@ -86,10 +86,11 @@ public class ActionsAPI {
                         }
                     }
                 }
-            } else if (pathstr[0].equals("snapshot")) if (repository.containsModule(packageName)) {
-                String snapshotName = request.getParameter(Parameters.SnapshotName.toString());
-                repository.createModuleSnapshot(packageName,
-                        snapshotName);
+            } else if (pathstr[0].equals("snapshot")) {
+                if (repository.containsModule(packageName)) {
+                    String snapshotName = request.getParameter(Parameters.SnapshotName.toString());
+                    repository.createModuleSnapshot(packageName, snapshotName);
+                }
             } else {
                 throw new RulesRepositoryException("Unknown action request: "
                         + request.getContextPath());


### PR DESCRIPTION
ActionsAPIServlet does nothing and returns 'OK'
https://issues.jboss.org/browse/GUVNOR-1906

I made two commits. One is for making ActionsAPIServlet work. The other is for throwing an Exception properly in case of wrong action.

ActionAPIServletIntegrationTest did't fail without this fix because MockHTTPRequest doesn't implement getPathTranslated() to return its file path like a real one... 

I'm not including a test case because IntegrationTest seems to be in a way of changing project structure. I did manual test anyway.
