### PR TITLE
GUVNOR-1607: Add support for GZIP in jax-rs REST API

### DIFF
--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/jaxrs/CategoryResource.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/jaxrs/CategoryResource.java
@@ -22,6 +22,7 @@ import org.apache.abdera.factory.Factory;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Feed;
 import org.apache.abdera.model.Link;
+import org.apache.cxf.annotations.GZIP;
 import org.drools.guvnor.server.jaxrs.jaxb.*;
 import org.drools.repository.AssetItem;
 import org.drools.repository.AssetItemPageResult;
@@ -52,6 +53,7 @@ import org.jboss.resteasy.plugins.providers.atom.Link;*/
 @Path("/categories")
 @RequestScoped
 @Named
+@GZIP
 public class CategoryResource extends Resource {
 
     private final int pageSize = 10;

--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/jaxrs/PackageResource.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/jaxrs/PackageResource.java
@@ -24,6 +24,7 @@ import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.ExtensibleElement;
 import org.apache.abdera.model.Feed;
 import org.apache.abdera.model.Link;
+import org.apache.cxf.annotations.GZIP;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.drools.guvnor.client.rpc.BuilderResult;
 import org.drools.guvnor.client.rpc.BuilderResultLine;
@@ -92,6 +93,7 @@ import static org.drools.guvnor.server.jaxrs.Translator.toPackageEntryAbdera;
 @Path("/packages")
 @RequestScoped
 @Named
+@GZIP
 public class PackageResource extends Resource {
     private HttpHeaders headers;
 


### PR DESCRIPTION
In order to support GZIP in the new jax-rs based REST API all you have to do is annotate with @GZIP
