### PR TITLE
Remove netty jar from jboss-as7 distribution. It is already provied by AS

### DIFF
--- a/guvnor-distribution-wars/src/main/assembly/assembly-guvnor-jboss-as-7_0.xml
+++ b/guvnor-distribution-wars/src/main/assembly/assembly-guvnor-jboss-as-7_0.xml
@@ -76,6 +76,10 @@
           <exclude>WEB-INF/lib/weld-*.jar</exclude>
           <exclude>WEB-INF/lib/javax*.jar</exclude>
           <exclude>WEB-INF/lib/jboss-interceptors-api_1-*.jar</exclude>
+
+          <!-- Netty-->
+          <exclude>WEB-INF/lib/netty-3*.jar</exclude>
+
         </excludes>
       </unpackOptions>
       <useStrictFiltering>true</useStrictFiltering>


### PR DESCRIPTION
If not removing this netty jar, there is deployment error when deploy Guvnor in EAP6.1
