### PR TITLE
Update BPMN2ProcessHandler.java

### DIFF
--- a/guvnor-webapp-drools/src/main/java/org/drools/guvnor/server/contenthandler/drools/BPMN2ProcessHandler.java
+++ b/guvnor-webapp-drools/src/main/java/org/drools/guvnor/server/contenthandler/drools/BPMN2ProcessHandler.java
@@ -146,7 +146,10 @@ public class BPMN2ProcessHandler extends ContentHandler
                         // Put the old contents back as there is no updating possible
                         repoAsset.updateContent( content.getXml() );
                     }
-            	}
+            	} else {
+                        // Handle content for assets other than bpmn/bpmn2
+                        repoAsset.updateContent( content.getXml() );
+                }
             }
             if ( content.getJson() != null ) {
                 try {


### PR DESCRIPTION
While save should have already been handled, the only files that were being handled were bpmn/bpmn2 files. This patch should handle all asset files with xml as their content.
