### PR TITLE
register guvnor maven repo on startup

### DIFF
--- a/guvnor/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -78,6 +78,7 @@ public class GuvnorM2Repository {
         if (!releasesRepository.exists()) {
             releasesRepository.mkdirs();
         }
+        Aether.DEFUALT_AETHER.getRepositories().add(getGuvnorM2Repository());
     }
 
     protected String getM2RepositoryRootDir() {


### PR DESCRIPTION
this change adds guvnor maven repository during startup of the bean so what ever service is going to rely on (jbpm runtime will deploy artifacts from maven repo on application startup) will get it initialized without direct knowledge about maven repo configuration - like its location
