### PR TITLE
Fixes : "401 This user has no permissions setup" 

### DIFF
--- a/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/security/SecurityServiceImpl.java
+++ b/guvnor-webapp-core/src/main/java/org/drools/guvnor/server/security/SecurityServiceImpl.java
@@ -98,7 +98,7 @@ public class SecurityServiceImpl
     public UserSecurityContext getCurrentUser() {
         tryAutoLoginAsGuest();
         final String userName = identity.isLoggedIn() ? credentials.getUsername() : null;
-        final boolean isAdministrator = getUserCapabilities().contains( Capability.SHOW_ADMIN );
+        final boolean isAdministrator = userName == null ? false : getUserCapabilities().contains( Capability.SHOW_ADMIN );
         return new UserSecurityContext( userName,
                                         isAdministrator );
     }


### PR DESCRIPTION
before login page when guvnorSecurity:enableRoleBasedAuthorization is activated

Ref : http://drools.46999.n3.nabble.com/How-configure-Guvnor-5-4-JAAS-with-jboss-7-0-2-td4020424.html#a4020854
