### PR TITLE
BZ-1000592 - Provide the user with an information message why 'build&dep...

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/builder/model/DeployResult.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/builder/model/DeployResult.java
@@ -12,6 +12,7 @@ public class DeployResult {
 
     private GAV gav;
     private List<BuildMessage> messages = new ArrayList<BuildMessage>();
+    private List<BuildMessage> deployMessages = new ArrayList<BuildMessage>();
 
     public DeployResult() {
         //Marshalling
@@ -31,6 +32,14 @@ public class DeployResult {
 
     public void setBuildMessages( final List<BuildMessage> messages ) {
         this.messages = messages;
+    }
+
+    public List<BuildMessage> getDeployMessages() {
+        return Collections.unmodifiableList( deployMessages );
+    }
+
+    public void addDeployMessage( final BuildMessage message ) {
+        this.deployMessages.add( message );
     }
 
 }

--- a/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/BuildServiceImpl.java
+++ b/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/BuildServiceImpl.java
@@ -17,6 +17,7 @@
 package org.guvnor.common.services.builder;
 
 import java.io.ByteArrayInputStream;
+import java.util.List;
 import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -24,6 +25,7 @@ import javax.inject.Inject;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
+import org.guvnor.common.services.project.builder.model.BuildMessage;
 import org.guvnor.common.services.project.builder.model.BuildResults;
 import org.guvnor.common.services.project.builder.model.DeployResult;
 import org.guvnor.common.services.project.builder.model.IncrementalBuildResults;
@@ -98,11 +100,13 @@ public class BuildServiceImpl
                 DeployResult deployResult = new DeployResult( pom.getGav() );
                 deployResult.setBuildMessages( results.getMessages() );
                 deployResultEvent.fire( deployResult );
-
-            } else {
-                DeployResult deployResult = new DeployResult( pom.getGav() );
-                deployResult.setBuildMessages( results.getMessages() );
-                deployResultEvent.fire( deployResult );
+                // add deploy messages if any
+                List<BuildMessage> deployMessages = deployResult.getDeployMessages();
+                if (!deployMessages.isEmpty()) {
+                    for (BuildMessage message : deployMessages) {
+                        results.addBuildMessage(message);
+                    }
+                }
             }
 
             return results;


### PR DESCRIPTION
...loy' failed

Allows to add deploy messages to be presented on Problems Panel. Additionally removes the else statement that produced DeployResult even though the maven deploy did not happen due to errors being found after build.
