### PR TITLE
- Moving the (hard-coded) version for tests to a properties file

### DIFF
--- a/guvnor-webapp-drools/pom.xml
+++ b/guvnor-webapp-drools/pom.xml
@@ -26,6 +26,16 @@
   </properties>
 
   <build>
+  
+    <testResources>
+        <testResource>
+            <directory>src/test/resources</directory>
+        </testResource>
+        <testResource>
+            <directory>src/test/filtered-resources</directory>
+            <filtering>true</filtering>
+        </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <!--use -Dgwt.compiler.skip=true to skip GWT compiler -->

--- a/guvnor-webapp-drools/src/test/filtered-resources/test.properties
+++ b/guvnor-webapp-drools/src/test/filtered-resources/test.properties
@@ -1,0 +1,1 @@
+project.version=${project.version}

--- a/guvnor-webapp-drools/src/test/java/org/drools/guvnor/server/test/GuvnorIntegrationTest.java
+++ b/guvnor-webapp-drools/src/test/java/org/drools/guvnor/server/test/GuvnorIntegrationTest.java
@@ -45,10 +45,13 @@ import org.junit.runner.RunWith;
 import org.picketlink.idm.impl.api.PasswordCredential;
 
 import javax.inject.Inject;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
+import java.util.Properties;
 import java.util.TreeMap;
 
 @RunWith(Arquillian.class)
@@ -57,13 +60,17 @@ public abstract class GuvnorIntegrationTest {
     public static final String ADMIN_USERNAME = "admin";
 
     @Deployment
-    public static WebArchive createDeployment() {
+    public static WebArchive createDeployment() throws Exception {
         WebArchive webArchive = ShrinkWrap.create(MavenImporter.class).loadEffectivePom("pom.xml")
                 .importBuildOutput().importTestBuildOutput()
                 .as(WebArchive.class);
         addTestDependencies(webArchive);
 
-        File explodedWarFile = new File("target/guvnor-webapp-drools-5.5.1-SNAPSHOT");
+        Properties testProps = new Properties();
+        testProps.load(GuvnorIntegrationTest.class.getResourceAsStream("/test.properties"));
+        String version = testProps.getProperty("project.version");
+        
+        File explodedWarFile = new File("target/guvnor-webapp-drools-" + version );
         if (!explodedWarFile.exists()) {
             throw new IllegalStateException("The exploded war file (" + explodedWarFile
                     + ") should exist, run \"mvn package\" first.");


### PR DESCRIPTION
Finding and using the project version (for war names) common problem with arquillian tests. This is how I usually solve it so that I don't have to change it with each update. 
