### PR TITLE
jcr2vfs: add jbpm-bpmn2 into droolsjbpm uberjar

### DIFF
--- a/guvnor-jcr2vfs-migration/guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar/pom.xml
+++ b/guvnor-jcr2vfs-migration/guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar/pom.xml
@@ -30,17 +30,22 @@
                 <artifactItem>
                   <groupId>org.drools</groupId>
                   <artifactId>knowledge-api</artifactId>
-                  <version>${project.version}</version>
+                  <version>${drools.version}</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.drools</groupId>
                   <artifactId>drools-core</artifactId>
-                  <version>${project.version}</version>
+                  <version>${drools.version}</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.drools</groupId>
                   <artifactId>drools-compiler</artifactId>
-                  <version>${project.version}</version>
+                  <version>${drools.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.jbpm</groupId>
+                  <artifactId>jbpm-bpmn2</artifactId>
+                  <version>${jbpm.version}</version>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/unpacked</outputDirectory>


### PR DESCRIPTION
- the jcr2vfs migration tool requires the jbpm-bpmn2 in version 5.x.
  This change makes sure correct version is included directly in the
  uberjar and does not have to listed in the jcr2vfs pom
- also changed the ${project.version} to ${drools.version}; although
  they are the same, the drools.version better reflects the
  usage here
