### PR TITLE
BPMSPL-74 -- adding operation to retrieve a (k)jar from the repository

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -40,6 +40,7 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
@@ -65,6 +66,9 @@ import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.artifact.SubArtifact;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.guvnor.common.services.project.model.GAV;
@@ -877,6 +881,37 @@ public class GuvnorM2Repository {
         }
 
         return stringWriter.toString();
+    }
+    
+    public File getArtifactFileFromRepository( final GAV gav ) { 
+     
+        
+        ArtifactRequest request = new ArtifactRequest();
+        request.addRepository(getGuvnorM2Repository());
+        DefaultArtifact artifact = new DefaultArtifact(gav.getGroupId(),
+                                                       gav.getArtifactId(), 
+                                                       "jar", 
+                                                       gav.getVersion());
+        request.setArtifact(artifact);
+        ArtifactResult result = null;
+        try {
+            result = Aether.getAether().getSystem().resolveArtifact(
+                    Aether.getAether().getSession(), 
+                    request);
+        } catch( ArtifactResolutionException e ) {
+            log.error( e.getMessage(), e );
+        }
+        
+        if( result == null ) { 
+            return null;
+        }
+      
+        File artifactFile = null;
+        if( result.isResolved() && ! result.isMissing() ) { 
+           artifactFile = result.getArtifact().getFile();
+        }
+        
+        return artifactFile;
     }
 }
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryTest.java
@@ -16,13 +16,21 @@
 
 package org.guvnor.m2repo.backend.server;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
@@ -35,8 +43,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.*;
 
 public class M2RepositoryTest {
 
@@ -79,7 +85,7 @@ public class M2RepositoryTest {
     }
 
     @Test
-    public void testDeployArtifact() throws Exception {
+    public void testDeployArtifactAndGetArtifactFile() throws Exception {
         GuvnorM2Repository repo = new GuvnorM2Repository();
         repo.init();
 
@@ -109,6 +115,20 @@ public class M2RepositoryTest {
 
         assertTrue( "Did not find expected file after calling M2Repository.addFile()",
                     found );
+      
+        // Test get artifact file
+        File file = repo.getArtifactFileFromRepository(gav);
+        assertNotNull( "Empty file for artifact", file );
+        JarFile jarFile = new JarFile(file);
+        int count = 0;
+       
+        String lastEntryName = null;
+        for( Enumeration<JarEntry> entries = jarFile.entries(); entries.hasMoreElements(); ) { 
+            ++count;
+            JarEntry entry = entries.nextElement();
+            assertNotEquals( "Endless loop.", lastEntryName, entry.getName() );
+        }
+        assertTrue( "Empty jar file!", count > 0 );
     }
 
     @Test


### PR DESCRIPTION
One of the requested features (aiming for milestone 1) is a REST operation to retrieve a process image.

However, the default way to do this is retrieve the process image .svg file that has been stored in the deployed deployment in the repository. This PR relates to retrieving a (k)jar from the repository on the server side in order to then extract the process image SVG file from the jar.  