### PR TITLE
guvnor-webapp: don't build GWT permutations for IE8 and older

### DIFF
--- a/guvnor-webapp/src/main/resources/org/guvnor/GuvnorWorkbench.gwt.xml
+++ b/guvnor-webapp/src/main/resources/org/guvnor/GuvnorWorkbench.gwt.xml
@@ -85,4 +85,6 @@
   <extend-property name="locale" values="pt_BR"/>
   <extend-property name="locale" values="zh_CN"/>
 
+  <!-- We don't need to support IE8 or older -->
+  <set-property name="user.agent" value="gecko1_8,safari,ie9,ie10"/>
 </module>


### PR DESCRIPTION
It seems we are not supporting IE8 and older (at least not in kie-wb and kie-drools-wb) so there is no need to build these permutations.