### PR TITLE
BZ1265901: NullPointerException with kie-config-cli.sh after migration from 6.1.0 to 6.1.2

### DIFF
--- a/guvnor-structure/guvnor-structure-backend/src/main/java/org/guvnor/structure/backend/backcompat/BackwardCompatibleUtil.java
+++ b/guvnor-structure/guvnor-structure-backend/src/main/java/org/guvnor/structure/backend/backcompat/BackwardCompatibleUtil.java
@@ -40,10 +40,16 @@ public class BackwardCompatibleUtil {
     public ConfigGroup compat( final ConfigGroup configGroup ) {
         if ( configGroup != null ) {
             final ConfigItem<List<String>> roles = configGroup.getConfigItem( "security:roles" );
-            if ( roles != null && !roles.getValue().isEmpty() ) {
-                configGroup.addConfigItem( configurationFactory.newConfigItem( "security:groups", new ArrayList<String>( roles.getValue() ) ) );
+            if ( roles != null ) {
+                configGroup.addConfigItem( configurationFactory.newConfigItem( "security:groups",
+                                                                               new ArrayList<String>( roles.getValue() ) ) );
+                configGroup.removeConfigItem( "security:roles" );
             }
-            configGroup.removeConfigItem( "security:roles" );
+            final ConfigItem<List<String>> groups = configGroup.getConfigItem( "security:groups" );
+            if ( groups == null ) {
+                configGroup.addConfigItem( configurationFactory.newConfigItem( "security:groups",
+                                                                               new ArrayList<String>() ) );
+            }
         }
         return configGroup;
     }

--- a/guvnor-structure/guvnor-structure-backend/src/test/java/org/guvnor/structure/backend/backcompat/BackwardCompatibleUtilTest.java
+++ b/guvnor-structure/guvnor-structure-backend/src/test/java/org/guvnor/structure/backend/backcompat/BackwardCompatibleUtilTest.java
@@ -29,32 +29,58 @@ import static org.junit.Assert.*;
 public class BackwardCompatibleUtilTest {
 
     @Test
-    public void backwardCompatTest() {
+    public void backwardCompatibilityNullTest() {
         final ConfigurationFactory factory = new ConfigurationFactoryImpl();
         final BackwardCompatibleUtil backwardUtil = new BackwardCompatibleUtil( factory );
 
         assertNull( backwardUtil.compat( null ) );
+    }
 
-        final ConfigGroup group1 = factory.newConfigGroup( ConfigType.PROJECT, "cool", "test" );
-        assertNotNull( backwardUtil.compat( group1 ) );
-        assertNull( backwardUtil.compat( group1 ).getConfigItem( "security:groups" ) );
+    @Test
+    public void backwardCompatibilityNullSecurityRolesTest() {
+        final ConfigurationFactory factory = new ConfigurationFactoryImpl();
+        final BackwardCompatibleUtil backwardUtil = new BackwardCompatibleUtil( factory );
 
-        group1.addConfigItem( factory.newConfigItem( "security:groups", new ArrayList() {{
-            add( "group1" );
-        }} ) );
-        assertNotNull( backwardUtil.compat( group1 ).getConfigItem( "security:groups" ) );
-        assertTrue( ( (List<String>) ( backwardUtil.compat( group1 ).getConfigItem( "security:groups" ) ).getValue() ).size() == 1 );
+        final ConfigGroup group = factory.newConfigGroup( ConfigType.PROJECT,
+                                                          "cool",
+                                                          "test" );
+        assertNotNull( backwardUtil.compat( group ) );
+        assertNotNull( backwardUtil.compat( group ).getConfigItem( "security:groups" ) );
+    }
 
-        final ConfigGroup group2 = factory.newConfigGroup( ConfigType.PROJECT, "cool2", "test2" );
-        assertNotNull( backwardUtil.compat( group2 ) );
-        assertNull( backwardUtil.compat( group2 ).getConfigItem( "security:groups" ) );
+    @Test
+    public void backwardCompatibilityExistingSecurityRolesTest() {
+        final ConfigurationFactory factory = new ConfigurationFactoryImpl();
+        final BackwardCompatibleUtil backwardUtil = new BackwardCompatibleUtil( factory );
 
-        group2.addConfigItem( factory.newConfigItem( "security:roles", new ArrayList() {{
-            add( "group1" );
-        }} ) );
-        assertNotNull( backwardUtil.compat( group2 ).getConfigItem( "security:groups" ) );
-        assertTrue( ( (List<String>) ( backwardUtil.compat( group2 ).getConfigItem( "security:groups" ) ).getValue() ).size() == 1 );
-        assertNull( backwardUtil.compat( group2 ).getConfigItem( "security:roles" ) );
+        final ConfigGroup group = factory.newConfigGroup( ConfigType.PROJECT,
+                                                          "cool2",
+                                                          "test2" );
+
+        group.addConfigItem( factory.newConfigItem( "security:roles",
+                                                    new ArrayList() {{
+                                                        add( "group1" );
+                                                    }} ) );
+        assertNotNull( backwardUtil.compat( group ).getConfigItem( "security:groups" ) );
+        assertEquals( 1,
+                      ( (List<String>) ( backwardUtil.compat( group ).getConfigItem( "security:groups" ) ).getValue() ).size() );
+        assertNull( backwardUtil.compat( group ).getConfigItem( "security:roles" ) );
+    }
+
+    @Test
+    public void backwardCompatibilityEmptySecurityRolesTest() {
+        final ConfigurationFactory factory = new ConfigurationFactoryImpl();
+        final BackwardCompatibleUtil backwardUtil = new BackwardCompatibleUtil( factory );
+
+        final ConfigGroup group = factory.newConfigGroup( ConfigType.PROJECT,
+                                                          "cool3",
+                                                          "test3" );
+
+        group.addConfigItem( factory.newConfigItem( "security:roles", new ArrayList() ) );
+        assertNotNull( backwardUtil.compat( group ).getConfigItem( "security:groups" ) );
+        assertEquals( 0,
+                      ( (List<String>) ( backwardUtil.compat( group ).getConfigItem( "security:groups" ) ).getValue() ).size() );
+        assertNull( backwardUtil.compat( group ).getConfigItem( "security:roles" ) );
     }
 
 }


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1265901

The cause was that if the "old" ```ConfigGroup``` did not have a ```security:roles``` entry a "new" ```security:groups``` entry was not created; however ```RepositoryServiceImpl.addGroup(...)``` always expects a non-null ```security:groups``` entry.