### PR TITLE
BZ-1273109 - BPM cluster: Job executor fails with NPE while

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/resources/ExecuteOperation.bpmn2
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/resources/ExecuteOperation.bpmn2
@@ -9,6 +9,7 @@
   <bpmn2:itemDefinition id="_JobRequestItem" structureRef="org.guvnor.rest.client.JobRequest"/>
   <bpmn2:itemDefinition id="_RetriesItem" structureRef="Integer"/>
   <bpmn2:itemDefinition id="_OwnerItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_BusinessKeyItem" structureRef="String"/>
   <bpmn2:error id="java.lang.RuntimeException" errorCode="java.lang.RuntimeException"/>
   <bpmn2:itemDefinition id="__5D7392FA-7863-4ECE-AE2E-2A55B32CA6E8_OperationInputXItem" structureRef="Object"/>
   <bpmn2:itemDefinition id="__5D7392FA-7863-4ECE-AE2E-2A55B32CA6E8_RequestorInputXItem" structureRef="Object"/>
@@ -20,6 +21,7 @@
   <bpmn2:itemDefinition id="__DF37F979-03D2-4369-9B70-8BC61144CD80_JobRequestInputXItem" structureRef="Object"/>
   <bpmn2:itemDefinition id="__DF37F979-03D2-4369-9B70-8BC61144CD80_retriesInputXItem" structureRef="Integer"/>
   <bpmn2:itemDefinition id="__DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__DF37F979-03D2-4369-9B70-8BC61144CD80_businessKeyInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__DF37F979-03D2-4369-9B70-8BC61144CD80_ResultOutputXItem" structureRef="java.lang.Object"/>
   <bpmn2:process id="guvnor-asset-management.ExecuteOperation" drools:packageName="org.jbpm" drools:version="1.0" name="ExecuteOperation" isExecutable="true">
     <bpmn2:property id="Operation" itemSubjectRef="_OperationItem"/>
@@ -31,6 +33,7 @@
     <bpmn2:property id="JobRequest" itemSubjectRef="_JobRequestItem"/>
     <bpmn2:property id="Retries" itemSubjectRef="_RetriesItem"/>
     <bpmn2:property id="Owner" itemSubjectRef="_OwnerItem"/>
+    <bpmn2:property id="BusinessKey" itemSubjectRef="_BusinessKeyItem"/>
     <bpmn2:startEvent id="_0C2F9495-DDED-4E42-ABC2-8502AD179D8A" drools:bgcolor="#9acd32" drools:selectable="true" name="">
       <bpmn2:outgoing>_B964100D-B199-4D76-AF84-A24BCD30598B</bpmn2:outgoing>
     </bpmn2:startEvent>
@@ -104,6 +107,7 @@
         <bpmn2:dataInput id="_DF37F979-03D2-4369-9B70-8BC61144CD80_JobRequestInputX" drools:dtype="Object" itemSubjectRef="__DF37F979-03D2-4369-9B70-8BC61144CD80_JobRequestInputXItem" name="JobRequest"/>
         <bpmn2:dataInput id="_DF37F979-03D2-4369-9B70-8BC61144CD80_retriesInputX" drools:dtype="Integer" itemSubjectRef="__DF37F979-03D2-4369-9B70-8BC61144CD80_retriesInputXItem" name="Retries"/>
         <bpmn2:dataInput id="_DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputX" drools:dtype="Integer" itemSubjectRef="__DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputXItem" name="Owner"/>
+        <bpmn2:dataInput id="_DF37F979-03D2-4369-9B70-8BC61144CD80_businessKeyInputX" drools:dtype="String" itemSubjectRef="__DF37F979-03D2-4369-9B70-8BC61144CD80_businessKeyInputXItem" name="BusinessKey"/>
         <bpmn2:dataOutput id="_DF37F979-03D2-4369-9B70-8BC61144CD80_ResultOutputX" drools:dtype="java.lang.Object" itemSubjectRef="__DF37F979-03D2-4369-9B70-8BC61144CD80_ResultOutputXItem" name="Result"/>
         <bpmn2:inputSet id="_qrgC4UsVEeSBnoD097BQOA">
           <bpmn2:dataInputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_CommandClassInputX</bpmn2:dataInputRefs>
@@ -111,6 +115,7 @@
           <bpmn2:dataInputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_retriesInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_businessKeyInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
         <bpmn2:outputSet id="_qrgC4ksVEeSBnoD097BQOA">
           <bpmn2:dataOutputRefs>_DF37F979-03D2-4369-9B70-8BC61144CD80_ResultOutputX</bpmn2:dataOutputRefs>
@@ -138,6 +143,10 @@
       <bpmn2:dataInputAssociation id="_qrgC6UsVEeSBnoD097BQOC">
         <bpmn2:sourceRef>Owner</bpmn2:sourceRef>
         <bpmn2:targetRef>_DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qrgC6UsVEeSBnoD097BQOD">
+        <bpmn2:sourceRef>BusinessKey</bpmn2:sourceRef>
+        <bpmn2:targetRef>_DF37F979-03D2-4369-9B70-8BC61144CD80_businessKeyInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
     </bpmn2:task>
     <bpmn2:sequenceFlow id="_D9945BDE-2132-4824-875B-547A413949E9" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_DEEFF075-0306-4773-89AE-4C9D06B85B46" targetRef="_DF37F979-03D2-4369-9B70-8BC61144CD80">

--- a/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
+++ b/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
@@ -190,6 +190,7 @@ public class JobRequestScheduler {
     protected CommandContext getContext(JobRequest jobRequest) {
         CommandContext ctx = new CommandContext();
         ctx.setData(JOB_REQUEST_KEY, jobRequest);
+        ctx.setData("BusinessKey", jobRequest.getJobId());
         ctx.setData("Retries", 0);
         ctx.setData("Owner", ExecutorService.EXECUTOR_ID);
 

--- a/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobResultManager.java
+++ b/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobResultManager.java
@@ -15,15 +15,28 @@
 
 package org.guvnor.rest.backend;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 
+import org.guvnor.rest.client.JobRequest;
 import org.guvnor.rest.client.JobResult;
+import org.guvnor.rest.client.JobStatus;
+import org.kie.api.executor.CommandContext;
+import org.kie.api.executor.ExecutionResults;
+import org.kie.api.executor.ExecutorService;
+import org.kie.api.executor.RequestInfo;
+import org.kie.api.runtime.query.QueryContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +68,9 @@ public class JobResultManager {
 
     private int maxCacheSize = 10000;
 
+    @Inject
+    private Instance<ExecutorService> jobExecutor;
+
     @PostConstruct
     public void start() {
         if (!created.compareAndSet(0, 1)) {
@@ -65,7 +81,37 @@ public class JobResultManager {
     }
 
     public JobResult getJob(String jobId) {
-        return jobs.get(jobId);
+        JobResult job = jobs.get(jobId);
+
+        if (job != null && !JobStatus.ACCEPTED.equals(job.getStatus())) {
+            return job;
+        }
+
+        if (!jobExecutor.isUnsatisfied()) {
+
+            List<RequestInfo> jobsFound = jobExecutor.get().getRequestsByBusinessKey(jobId, new QueryContext());
+
+            if (jobsFound != null && !jobsFound.isEmpty()) {
+                RequestInfo executorJob = jobsFound.get(0);
+                JobResult requestedJob = (JobResult) getItemFromRequestOutput("JobResult", executorJob);
+                if (requestedJob == null) {
+                    JobRequest jobRequest = (JobRequest) getItemFromRequestInput("JobRequest", executorJob);
+                    if (jobRequest != null) {
+                        requestedJob = new JobResult();
+                        requestedJob.setJobId(jobRequest.getJobId());
+                        requestedJob.setStatus(jobRequest.getStatus());
+                    }
+                }
+
+                // if it was found set it in cache
+                if (requestedJob != null) {
+                    job = requestedJob;
+                    jobs.put(jobId, job);
+                }
+            }
+        }
+
+        return job;
     }
 
     public void putJob(JobResult job) {
@@ -74,5 +120,61 @@ public class JobResultManager {
 
     public JobResult removeJob(String jobId) {
         return jobs.remove(jobId);
+    }
+
+    protected Object getItemFromRequestInput(String itemName, RequestInfo requestInfo) {
+        CommandContext ctx = null;
+        byte[] requestData = requestInfo.getRequestData();
+        if (requestData != null) {
+            ObjectInputStream in = null;
+            try {
+                in = new ObjectInputStream(new ByteArrayInputStream(requestData));
+                ctx = (CommandContext) in.readObject();
+            } catch (Exception e) {
+                logger.debug("Exception while deserializing context data of job with id {}", requestInfo.getId(), e);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException e) {
+
+                    }
+                }
+            }
+        }
+
+        if (ctx != null && ctx.getData(itemName) != null) {
+            return ctx.getData(itemName);
+        }
+
+        return null;
+    }
+
+    protected Object getItemFromRequestOutput(String itemName, RequestInfo requestInfo) {
+        ExecutionResults execResults = null;
+        byte[] responseData = requestInfo.getResponseData();
+        if (responseData != null) {
+            ObjectInputStream in = null;
+            try {
+                in = new ObjectInputStream(new ByteArrayInputStream(responseData));
+                execResults = (ExecutionResults) in.readObject();
+            } catch (Exception e) {
+                logger.debug("Exception while deserializing context data of job with id {}", requestInfo.getId(), e);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException e) {
+
+                    }
+                }
+            }
+        }
+
+        if (execResults != null && execResults.getData(itemName) != null) {
+            return execResults.getData(itemName);
+        }
+
+        return null;
     }
 }

--- a/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/AbstractJobCommand.java
+++ b/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/AbstractJobCommand.java
@@ -105,7 +105,10 @@ public abstract class AbstractJobCommand implements Command {
                 jobMgr.putJob(result);
             }
 
-            return getEmptyResult();
+            ExecutionResults results = getEmptyResult();
+            results.setData("JobResult", result);
+
+            return results;
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
this PR enables efficient and reliable job status checks within cluster. Since all the commands/jobs are executed asynchronously (via processes and jbpm executor) they might be executed on any cluster member. Thus when running clustered environment default map based cache did not work properly when request for checking job status was sent to other instance then the job was actually executed.
This PR uses executorService (component that actually executed the job) to find it in db in case it does not exist in the local cache. That way job status check is cluster aware and will cover efficient job execution distribution across cluster members while still allowing to find the job status regardless where it was executed. 
Especially important when kie-wb instances are running behind load balancer.

ExecuteOperation process was enhanced to allow to pass custom business key that is then used to find the job to check it status. This business key is actually job id so it provides uniqueness and thus can be reliably searched.

this is one of three PRs for this BZ - others are in jbpm (https://github.com/droolsjbpm/jbpm/pull/317) and droolsjbpm-integration (https://github.com/droolsjbpm/droolsjbpm-integration/pull/212), though they don't have any compile dependency