### PR TITLE
BZ1263738: Misleading error message on startup: Could not find artifact org.guvnor:guvnor-asset-mgmt-project:jar

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -977,7 +977,7 @@ public class GuvnorM2Repository {
                     Aether.getAether().getSession(),
                     request );
         } catch ( ArtifactResolutionException e ) {
-            log.error( e.getMessage(), e );
+            log.warn( e.getMessage(), e );
         }
 
         if ( result == null ) {


### PR DESCRIPTION
(cherry picked from commit ea65e7b090ea85cf1b9f6da570c71ff4e05951f1)