### PR TITLE
BZ1274304: Clone Repository dialog doesn't show new Organizational Units

### DIFF
--- a/guvnor-organizationalunit-manager/pom.xml
+++ b/guvnor-organizationalunit-manager/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>guvnor-structure-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>
@@ -79,6 +84,20 @@
       <artifactId>uberfire-workbench-processors</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/guvnor-organizationalunit-manager/src/test/java/org/guvnor/organizationalunit/manager/client/editor/OrganizationalUnitManagerPresenterTest.java
+++ b/guvnor-organizationalunit-manager/src/test/java/org/guvnor/organizationalunit/manager/client/editor/OrganizationalUnitManagerPresenterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.organizationalunit.manager.client.editor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.organizationalunit.manager.client.editor.popups.AddOrganizationalUnitPopup;
+import org.guvnor.organizationalunit.manager.client.editor.popups.EditOrganizationalUnitPopup;
+import org.guvnor.structure.events.AfterCreateOrganizationalUnitEvent;
+import org.guvnor.structure.events.AfterDeleteOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
+import org.guvnor.structure.repositories.RepositoryService;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class OrganizationalUnitManagerPresenterTest {
+
+    @GwtMock
+    private AddOrganizationalUnitPopup addOrganizationalUnitPopup;
+
+    @GwtMock
+    private EditOrganizationalUnitPopup editOrganizationalUnitPopup;
+
+    @Mock
+    private EventSourceMock<AfterCreateOrganizationalUnitEvent> createOUEvent;
+
+    @Mock
+    private EventSourceMock<AfterDeleteOrganizationalUnitEvent> deleteOUEvent;
+
+    private OrganizationalUnitManagerView view = mock( OrganizationalUnitManagerView.class );
+
+    private OrganizationalUnitService mockOUService = mock( OrganizationalUnitService.class );
+    private Caller<OrganizationalUnitService> organizationalUnitService = new CallerMock<OrganizationalUnitService>( mockOUService );
+
+    private RepositoryService mockRepositoryService = mock( RepositoryService.class );
+    private Caller<RepositoryService> repositoryService = new CallerMock<RepositoryService>( mockRepositoryService );
+
+    private OrganizationalUnitManagerPresenter presenter;
+
+    private OrganizationalUnit mockOU = mock( OrganizationalUnit.class );
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        presenter = new OrganizationalUnitManagerPresenterImpl( view,
+                                                                organizationalUnitService,
+                                                                repositoryService,
+                                                                addOrganizationalUnitPopup,
+                                                                editOrganizationalUnitPopup,
+                                                                createOUEvent,
+                                                                deleteOUEvent );
+
+        when( mockOU.getName() ).thenReturn( "mock" );
+        when( mockOU.getOwner() ).thenReturn( "mock" );
+        when( mockOU.getDefaultGroupId() ).thenReturn( "mock" );
+
+        when( mockOUService.getOrganizationalUnits() ).thenReturn( new ArrayList<OrganizationalUnit>() );
+
+        when( mockOUService.createOrganizationalUnit( any( String.class ),
+                                                      any( String.class ),
+                                                      any( String.class ),
+                                                      any( Collection.class ) ) ).thenReturn( mockOU );
+
+        presenter.loadOrganizationalUnits();
+    }
+
+    @Test
+    public void testCreateOUEvent() {
+        presenter.createNewOrganizationalUnit( mockOU.getName(),
+                                               mockOU.getOwner(),
+                                               mockOU.getDefaultGroupId() );
+
+        verify( createOUEvent,
+                times( 1 ) ).fire( any( AfterCreateOrganizationalUnitEvent.class ) );
+    }
+
+    @Test
+    public void testDeleteOUEvent() {
+        presenter.deleteOrganizationalUnit( mockOU );
+
+        verify( deleteOUEvent,
+                times( 1 ) ).fire( any( AfterDeleteOrganizationalUnitEvent.class ) );
+    }
+
+}

--- a/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/events/AfterCreateOrganizationalUnitEvent.java
+++ b/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/events/AfterCreateOrganizationalUnitEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.structure.events;
+
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+/**
+ * An event signalling an Organizational Unit has been created
+ */
+public class AfterCreateOrganizationalUnitEvent {
+
+    private final OrganizationalUnit organizationalUnit;
+
+    public AfterCreateOrganizationalUnitEvent( final OrganizationalUnit organizationalUnit ) {
+        this.organizationalUnit = PortablePreconditions.checkNotNull( "organizationalUnit",
+                                                                      organizationalUnit );
+    }
+
+    public OrganizationalUnit getOrganizationalUnit() {
+        return organizationalUnit;
+    }
+
+}

--- a/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/events/AfterDeleteOrganizationalUnitEvent.java
+++ b/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/events/AfterDeleteOrganizationalUnitEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.structure.events;
+
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+/**
+ * An event signalling an Organizational Unit has been deleted
+ */
+public class AfterDeleteOrganizationalUnitEvent {
+
+    private final OrganizationalUnit organizationalUnit;
+
+    public AfterDeleteOrganizationalUnitEvent( final OrganizationalUnit organizationalUnit ) {
+        this.organizationalUnit = PortablePreconditions.checkNotNull( "organizationalUnit",
+                                                                      organizationalUnit );
+    }
+
+    public OrganizationalUnit getOrganizationalUnit() {
+        return organizationalUnit;
+    }
+
+}

--- a/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/organizationalunit/OrganizationalUnitService.java
+++ b/guvnor-structure/guvnor-structure-api/src/main/java/org/guvnor/structure/organizationalunit/OrganizationalUnitService.java
@@ -29,7 +29,7 @@ public interface OrganizationalUnitService {
 
     OrganizationalUnit createOrganizationalUnit( final String name,
                                                  final String owner,
-                                                 final String defaultGroupId);
+                                                 final String defaultGroupId );
 
     OrganizationalUnit createOrganizationalUnit( final String name,
                                                  final String owner,
@@ -37,8 +37,8 @@ public interface OrganizationalUnitService {
                                                  final Collection<Repository> repositories );
 
     OrganizationalUnit updateOrganizationalUnit( final String name,
-                                   final String owner,
-                                   final String defaultGroupId);
+                                                 final String owner,
+                                                 final String defaultGroupId );
 
     void addRepository( final OrganizationalUnit organizationalUnit,
                         final Repository repository );

--- a/guvnor-structure/guvnor-structure-api/src/main/resources/org/guvnor/structure/GuvnorStructureAPI.gwt.xml
+++ b/guvnor-structure/guvnor-structure-api/src/main/resources/org/guvnor/structure/GuvnorStructureAPI.gwt.xml
@@ -3,15 +3,16 @@
     "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
 <module>
 
-  <inherits name='org.jboss.errai.bus.ErraiBus'/>
-  <inherits name='org.uberfire.java.nio.UberfireNIO2Model'/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
+  <inherits name="org.uberfire.java.nio.UberfireNIO2Model"/>
   <inherits name="org.kie.uberfire.social.activities.SocialActivitiesAPI" />
 
-  <source path='config'/>
-  <source path='deployment'/>
-  <source path='navigator'/>
-  <source path='organizationalunit'/>
-  <source path='repositories'/>
-  <source path='social' />
+  <source path="config"/>
+  <source path="deployment"/>
+  <source path="events"/>
+  <source path="navigator"/>
+  <source path="organizationalunit"/>
+  <source path="repositories"/>
+  <source path="social" />
 
 </module>

--- a/guvnor-structure/guvnor-structure-client/pom.xml
+++ b/guvnor-structure/guvnor-structure-client/pom.xml
@@ -100,6 +100,19 @@
       <artifactId>gwtbootstrap3-extras</artifactId>
     </dependency>
 
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
@@ -21,9 +21,12 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.guvnor.structure.client.editors.repository.RepositoryPreferences;
+import org.guvnor.structure.events.AfterCreateOrganizationalUnitEvent;
+import org.guvnor.structure.events.AfterDeleteOrganizationalUnitEvent;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.repositories.EnvironmentParameters;
@@ -86,7 +89,6 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
 
     @Override
     public void handleCloneClick() {
-
         boolean urlConditionsMet = setUrl();
         boolean ouConditionsMet = setOrganizationalUnitGroupType();
         boolean nameConditionsMet = setNameGroupType();
@@ -94,6 +96,25 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
         if ( urlConditionsMet && ouConditionsMet && nameConditionsMet ) {
             repositoryService.call( getNormalizeRepositoryNameCallback() ).normalizeRepositoryName( view.getName() );
         }
+    }
+
+    public void onCreateOrganizationalUnit( @Observes final AfterCreateOrganizationalUnitEvent event ) {
+        final OrganizationalUnit organizationalUnit = event.getOrganizationalUnit();
+        if ( organizationalUnit == null ) {
+            return;
+        }
+        view.addOrganizationalUnit( organizationalUnit );
+        availableOrganizationalUnits.put( organizationalUnit.getName(),
+                                          organizationalUnit );
+    }
+
+    public void onDeleteOrganizationalUnit( @Observes final AfterDeleteOrganizationalUnitEvent event ) {
+        final OrganizationalUnit organizationalUnit = event.getOrganizationalUnit();
+        if ( organizationalUnit == null ) {
+            return;
+        }
+        view.deleteOrganizationalUnit( organizationalUnit );
+        availableOrganizationalUnits.remove( organizationalUnit.getName() );
     }
 
     private RemoteCallback<String> getNormalizeRepositoryNameCallback() {
@@ -206,6 +227,7 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
     }
 
     public void showForm() {
+        view.reset();
         view.show();
     }
 
@@ -217,8 +239,7 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
                                                 view.addOrganizationalUnitSelectEntry();
                                                 if ( organizationalUnits != null && !organizationalUnits.isEmpty() ) {
                                                     for ( OrganizationalUnit organizationalUnit : organizationalUnits ) {
-                                                        view.addOrganizationalUnit( organizationalUnit.getName(),
-                                                                                    organizationalUnit.getName() );
+                                                        view.addOrganizationalUnit( organizationalUnit );
                                                         availableOrganizationalUnits.put( organizationalUnit.getName(),
                                                                                           organizationalUnit );
                                                     }

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryView.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryView.java
@@ -16,6 +16,7 @@
 
 package org.guvnor.structure.client.editors.repository.clone;
 
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 public interface CloneRepositoryView {
@@ -36,8 +37,9 @@ public interface CloneRepositoryView {
 
     void addOrganizationalUnitSelectEntry();
 
-    void addOrganizationalUnit( String item,
-                                String value );
+    void addOrganizationalUnit( OrganizationalUnit ou );
+
+    void deleteOrganizationalUnit( OrganizationalUnit ou );
 
     String getSelectedOrganizationalUnit();
 
@@ -98,4 +100,7 @@ public interface CloneRepositoryView {
     void errorCloneRepositoryFail( Throwable cause );
 
     void errorLoadOrganizationalUnitsFail( Throwable cause );
+
+    void reset();
+
 }

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryViewImpl.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryViewImpl.java
@@ -19,6 +19,8 @@ package org.guvnor.structure.client.editors.repository.clone;
 import javax.enterprise.context.Dependent;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyPressHandler;
@@ -32,6 +34,7 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.structure.client.resources.i18n.CommonConstants;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.FormLabel;
@@ -47,7 +50,8 @@ import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.core.client.resources.i18n.CoreConstants;
 
 @Dependent
-public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositoryView, HasCloseHandlers<CloneRepositoryViewImpl> {
+public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositoryView,
+                                                                  HasCloseHandlers<CloneRepositoryViewImpl> {
 
     interface CloneRepositoryFormBinder
             extends
@@ -58,7 +62,6 @@ public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositor
     private CloneRepositoryView.Presenter presenter;
 
     private static CloneRepositoryFormBinder uiBinder = GWT.create( CloneRepositoryFormBinder.class );
-
 
     @UiField
     Button clone;
@@ -132,6 +135,15 @@ public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositor
                 nameHelpInline.setText( "" );
             }
         } );
+
+        organizationalUnitDropdown.addChangeHandler( new ChangeHandler() {
+            @Override
+            public void onChange( final ChangeEvent event ) {
+                organizationalUnitGroup.setValidationState( ValidationState.NONE );
+                organizationalUnitHelpInline.setText( "" );
+            }
+        } );
+
         gitURLTextBox.addKeyPressHandler( new KeyPressHandler() {
             @Override
             public void onKeyPress( final KeyPressEvent event ) {
@@ -150,13 +162,33 @@ public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositor
     }
 
     @Override
-    public void addOrganizationalUnit( final String item,
-                                       final String value ) {
+    public void addOrganizationalUnit( final OrganizationalUnit ou ) {
+        final String text = ou.getName();
+        final String value = ou.getName();
         final Option option = new Option();
-        option.setText( item );
+        option.setText( text );
         option.setValue( value );
         organizationalUnitDropdown.add( option );
         organizationalUnitDropdown.refresh();
+    }
+
+    @Override
+    public void deleteOrganizationalUnit( final OrganizationalUnit ou ) {
+        Option optToDelete = null;
+        for ( int i = 0; i < organizationalUnitDropdown.getWidgetCount(); i++ ) {
+            final Widget w = organizationalUnitDropdown.getWidget( i );
+            if ( w instanceof Option ) {
+                final Option o = (Option) w;
+                if ( o.getText().equals( ou.getName() ) ) {
+                    optToDelete = o;
+                    break;
+                }
+            }
+        }
+        if ( optToDelete != null ) {
+            organizationalUnitDropdown.remove( optToDelete );
+            organizationalUnitDropdown.refresh();
+        }
     }
 
     @Override
@@ -311,8 +343,28 @@ public class CloneRepositoryViewImpl extends BaseModal implements CloneRepositor
     }
 
     @Override
-    public HandlerRegistration addCloseHandler( CloseHandler<CloneRepositoryViewImpl> handler ) {
-        return addHandler(handler, CloseEvent.getType());
+    public HandlerRegistration addCloseHandler( final CloseHandler<CloneRepositoryViewImpl> handler ) {
+        return addHandler( handler,
+                           CloseEvent.getType() );
+    }
+
+    @Override
+    public void reset() {
+        nameTextBox.setText( "" );
+        nameGroup.setValidationState( ValidationState.NONE );
+        nameHelpInline.setText( "" );
+
+        organizationalUnitDropdown.deselectAll();
+        organizationalUnitDropdown.refresh();
+        organizationalUnitGroup.setValidationState( ValidationState.NONE );
+        organizationalUnitHelpInline.setText( "" );
+
+        gitURLTextBox.setText( "" );
+        urlGroup.setValidationState( ValidationState.NONE );
+        urlHelpInline.setText( "" );
+
+        usernameTextBox.setText( "" );
+        passwordTextBox.setText( "" );
     }
 
     @Override

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/create/CreateRepositoryForm.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/create/CreateRepositoryForm.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
@@ -38,6 +39,8 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.structure.client.editors.repository.RepositoryPreferences;
+import org.guvnor.structure.events.AfterCreateOrganizationalUnitEvent;
+import org.guvnor.structure.events.AfterDeleteOrganizationalUnitEvent;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.repositories.EnvironmentParameters;
@@ -59,6 +62,7 @@ import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
 import org.jboss.errai.ioc.client.container.IOCResolutionException;
 import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.commons.validation.PortablePreconditions;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.core.client.resources.i18n.CoreConstants;
@@ -74,15 +78,6 @@ public class CreateRepositoryForm extends Composite implements HasCloseHandlers<
     }
 
     private static CreateRepositoryFormBinder uiBinder = GWT.create( CreateRepositoryFormBinder.class );
-
-    @Inject
-    private Caller<RepositoryService> repositoryService;
-
-    @Inject
-    private Caller<OrganizationalUnitService> organizationalUnitService;
-
-    @Inject
-    private PlaceManager placeManager;
 
     @UiField
     FormGroup organizationalUnitGroup;
@@ -108,8 +103,28 @@ public class CreateRepositoryForm extends Composite implements HasCloseHandlers<
     @UiField
     BaseModal popup;
 
+    private Caller<RepositoryService> repositoryService;
+    private Caller<OrganizationalUnitService> organizationalUnitService;
+    private PlaceManager placeManager;
+
     private Map<String, OrganizationalUnit> availableOrganizationalUnits = new HashMap<String, OrganizationalUnit>();
     private boolean mandatoryOU = true;
+
+    public CreateRepositoryForm() {
+        //CDI proxy
+    }
+
+    @Inject
+    public CreateRepositoryForm( final Caller<RepositoryService> repositoryService,
+                                 final Caller<OrganizationalUnitService> organizationalUnitService,
+                                 final PlaceManager placeManager ) {
+        this.repositoryService = PortablePreconditions.checkNotNull( "repositoryService",
+                                                                     repositoryService );
+        this.organizationalUnitService = PortablePreconditions.checkNotNull( "organizationalUnitService",
+                                                                             organizationalUnitService );
+        this.placeManager = PortablePreconditions.checkNotNull( "placeManager",
+                                                                placeManager );
+    }
 
     @PostConstruct
     public void init() {
@@ -157,7 +172,7 @@ public class CreateRepositoryForm extends Composite implements HasCloseHandlers<
                                       ).getOrganizationalUnits();
     }
 
-    private boolean isOUMandatory() {
+    boolean isOUMandatory() {
         try {
             final IOCBeanDef<RepositoryPreferences> beanDef = IOC.getBeanManager().lookupBean( RepositoryPreferences.class );
             return beanDef == null || beanDef.getInstance().isOUMandatory();
@@ -252,6 +267,53 @@ public class CreateRepositoryForm extends Composite implements HasCloseHandlers<
 
     public void show() {
         popup.show();
+    }
+
+    public void onCreateOrganizationalUnit( @Observes final AfterCreateOrganizationalUnitEvent event ) {
+        final OrganizationalUnit organizationalUnit = event.getOrganizationalUnit();
+        if ( organizationalUnit == null ) {
+            return;
+        }
+        addOrganizationalUnit( organizationalUnit );
+        availableOrganizationalUnits.put( organizationalUnit.getName(),
+                                          organizationalUnit );
+    }
+
+    void addOrganizationalUnit( final OrganizationalUnit ou ) {
+        final String text = ou.getName();
+        final String value = ou.getName();
+        final Option option = new Option();
+        option.setText( text );
+        option.setValue( value );
+        organizationalUnitDropdown.add( option );
+        organizationalUnitDropdown.refresh();
+    }
+
+    public void onDeleteOrganizationalUnit( @Observes final AfterDeleteOrganizationalUnitEvent event ) {
+        final OrganizationalUnit organizationalUnit = event.getOrganizationalUnit();
+        if ( organizationalUnit == null ) {
+            return;
+        }
+        deleteOrganizationalUnit( organizationalUnit );
+        availableOrganizationalUnits.remove( organizationalUnit.getName() );
+    }
+
+    void deleteOrganizationalUnit( final OrganizationalUnit ou ) {
+        Option optToDelete = null;
+        for ( int i = 0; i < organizationalUnitDropdown.getWidgetCount(); i++ ) {
+            final Widget w = organizationalUnitDropdown.getWidget( i );
+            if ( w instanceof Option ) {
+                final Option o = (Option) w;
+                if ( o.getText().equals( ou.getName() ) ) {
+                    optToDelete = o;
+                    break;
+                }
+            }
+        }
+        if ( optToDelete != null ) {
+            organizationalUnitDropdown.remove( optToDelete );
+            organizationalUnitDropdown.refresh();
+        }
     }
 
 }

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenterTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenterTest.java
@@ -24,8 +24,11 @@ import org.guvnor.structure.client.editors.repository.clone.answer.OuServiceAnsw
 import org.guvnor.structure.client.editors.repository.clone.answer.RsCreateRepositoryAnswer;
 import org.guvnor.structure.client.editors.repository.clone.answer.RsCreateRepositoryFailAnswer;
 import org.guvnor.structure.client.editors.repository.clone.answer.RsNormalizedNameAnswer;
+import org.guvnor.structure.events.AfterCreateOrganizationalUnitEvent;
+import org.guvnor.structure.events.AfterDeleteOrganizationalUnitEvent;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
+import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryAlreadyExistsException;
 import org.guvnor.structure.repositories.RepositoryService;
@@ -50,7 +53,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CloneRepositoryFormTest {
+public class CloneRepositoryPresenterTest {
 
     private static final String ORG_UNIT_ONE = "OrganizationalUnitOne";
     private static final String ORG_UNIT_TWO = "OrganizationalUnitTwo";
@@ -320,6 +323,36 @@ public class CloneRepositoryFormTest {
     public void testCancelButton() {
         presenter.handleCancelClick();
         verify( view ).hide();
+    }
+
+    @Test
+    public void testCreateOUEvent() {
+        final OrganizationalUnit ou = new OrganizationalUnitImpl( "ou1",
+                                                                  "owner1",
+                                                                  "ou" );
+        presenter.onCreateOrganizationalUnit( new AfterCreateOrganizationalUnitEvent( ou ) );
+
+        verify( view,
+                times( 1 ) ).addOrganizationalUnit( ou );
+    }
+
+    @Test
+    public void testDeleteOUEvent() {
+        final OrganizationalUnit ou = new OrganizationalUnitImpl( "ou1",
+                                                                  "owner1",
+                                                                  "ou" );
+        presenter.onDeleteOrganizationalUnit( new AfterDeleteOrganizationalUnitEvent( ou ) );
+
+        verify( view,
+                times( 1 ) ).deleteOrganizationalUnit( ou );
+    }
+
+    @Test
+    public void testResetWhenShown() {
+        presenter.showForm();
+
+        verify( view,
+                times( 1 ) ).reset();
     }
 
     private void componentsNotAffected() {

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/create/CreateRepositoryFormTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/create/CreateRepositoryFormTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.structure.client.editors.repository.create;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.structure.events.AfterCreateOrganizationalUnitEvent;
+import org.guvnor.structure.events.AfterDeleteOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
+import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
+import org.guvnor.structure.repositories.RepositoryService;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.mocks.CallerMock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CreateRepositoryFormTest {
+
+    private RepositoryService mockRepositoryService = mock( RepositoryService.class );
+    private Caller<RepositoryService> repositoryService = new CallerMock<RepositoryService>( mockRepositoryService );
+
+    private OrganizationalUnitService mockOUService = mock( OrganizationalUnitService.class );
+    private Caller<OrganizationalUnitService> ouService = new CallerMock<OrganizationalUnitService>( mockOUService );
+    private PlaceManager placeManager = mock( PlaceManager.class );
+
+    private CreateRepositoryForm presenter;
+
+    @Before
+    public void setup() {
+        presenter = new CreateRepositoryForm( repositoryService,
+                                              ouService,
+                                              placeManager ) {
+            @Override
+            boolean isOUMandatory() {
+                //Override as we cannot mock IOC.getBeanManager()
+                return false;
+            }
+        };
+        presenter.init();
+    }
+
+    @Test
+    public void testCreateOUEvent() {
+        final OrganizationalUnit ou = new OrganizationalUnitImpl( "ou1",
+                                                                  "owner1",
+                                                                  "ou" );
+
+        final CreateRepositoryForm spy = spy( presenter );
+        spy.onCreateOrganizationalUnit( new AfterCreateOrganizationalUnitEvent( ou ) );
+
+        verify( spy,
+                times( 1 ) ).addOrganizationalUnit( ou );
+    }
+
+    @Test
+    public void testDeleteOUEvent() {
+        final OrganizationalUnit ou = new OrganizationalUnitImpl( "ou1",
+                                                                  "owner1",
+                                                                  "ou" );
+
+        final CreateRepositoryForm spy = spy( presenter );
+        spy.onDeleteOrganizationalUnit( new AfterDeleteOrganizationalUnitEvent( ou ) );
+
+        verify( spy,
+                times( 1 ) ).deleteOrganizationalUnit( ou );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1274304

I now raised events from Organizational Unit Manager when OUs are added or deleted. These are ```@Observe```d by the "Create Repository" and "Clone Repository" forms, which adjust their views accordingly. 

It should be noted the "Create Repository" form in ```guvnor-structure``` is no longer used (in kie-[drools]-wb) but replaced by the Wizard in ```guvnor-asset-mgmt-client```. I have however made the same changes to support observing OU changes for consistency. The Wizard "works" differently and always loads the list of available OUs each time it is shown so I did not need to change that.