### PR TITLE
Better arrow (U+2192) in Repository Structure title

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/java/org/guvnor/asset/management/client/editors/repository/structure/RepositoryStructurePresenter.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/java/org/guvnor/asset/management/client/editors/repository/structure/RepositoryStructurePresenter.java
@@ -401,7 +401,7 @@ public class RepositoryStructurePresenter
 
             changeTitleWidgetEvent.fire( new ChangeTitleWidgetEvent(
                     placeRequest,
-                    Constants.INSTANCE.RepositoryStructureWithName( getRepositoryLabel( repository ) + "- > "
+                    Constants.INSTANCE.RepositoryStructureWithName( getRepositoryLabel( repository ) + "→ "
                                                                             + model.getPOM().getGav().getArtifactId() + ":"
                                                                             + model.getPOM().getGav().getGroupId() + ":"
                                                                             + model.getPOM().getGav().getVersion() ) ) );
@@ -409,7 +409,7 @@ public class RepositoryStructurePresenter
         } else if ( model.isSingleProject() ) {
             changeTitleWidgetEvent.fire( new ChangeTitleWidgetEvent(
                     placeRequest,
-                    Constants.INSTANCE.RepositoryStructureWithName( getRepositoryLabel( repository ) + "- > " + model.getOrphanProjects().get( 0 ).getProjectName() ) ) );
+                    Constants.INSTANCE.RepositoryStructureWithName( getRepositoryLabel( repository ) + "→ " + model.getOrphanProjects().get( 0 ).getProjectName() ) ) );
 
         } else {
             changeTitleWidgetEvent.fire( new ChangeTitleWidgetEvent(


### PR DESCRIPTION
The string "- >" that should represent the relation between repository and a project inside it looks awkward with the font currently used in the worbench. I have replaced it with a unicode arrow.

Before:
![red hat jboss brms business central 2015-11-04 18-59-33](https://cloud.githubusercontent.com/assets/673386/10947258/4ffde2f2-8327-11e5-856d-e86eec08c123.png)

After:
![red hat jboss brms business central 2015-11-04 19-01-05](https://cloud.githubusercontent.com/assets/673386/10947264/56be9eec-8327-11e5-8aae-5f416ce2b8fa.png)
