### PR TITLE
BZ1193484: Roles added to Projects are ignored by Business Central

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Project.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Project.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.data.Cacheable;
 import org.uberfire.commons.validation.PortablePreconditions;
 import org.uberfire.security.authz.RuntimeContentResource;
 
@@ -28,7 +29,8 @@ import org.uberfire.security.authz.RuntimeContentResource;
  * An item representing a project
  */
 @Portable
-public class Project implements RuntimeContentResource {
+public class Project implements RuntimeContentResource,
+                                Cacheable {
 
     protected Path rootPath;
     protected Path pomXMLPath;
@@ -36,6 +38,7 @@ public class Project implements RuntimeContentResource {
     protected Collection<String> modules = new ArrayList<String>();
 
     private Collection<String> groups = new ArrayList<String>();
+    private boolean requiresRefresh = true;
 
     // only loaded by ProjectService.getProjects()
     private POM pom;
@@ -88,6 +91,16 @@ public class Project implements RuntimeContentResource {
     @Override
     public Collection<String> getTraits() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public void markAsCached() {
+        this.requiresRefresh = false;
+    }
+
+    @Override
+    public boolean requiresRefresh() {
+        return requiresRefresh;
     }
 
     public Collection<String> getModules() {

--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/ProjectRuntimeResourceManagerTest.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/ProjectRuntimeResourceManagerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server;
+
+import org.guvnor.common.services.project.model.Project;
+import org.junit.Test;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.security.impl.authz.RuntimeResourceManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ProjectRuntimeResourceManagerTest {
+
+    private RuntimeResourceManager manager = new RuntimeResourceManager();
+
+    @Test
+    //https://bugzilla.redhat.com/show_bug.cgi?id=1193484
+    public void testCachedRestrictionRefresh() {
+        final Path root = mock( Path.class );
+        when( root.toURI() ).thenReturn( "root" );
+        final Project p1_1 = new Project( root,
+                                          mock( Path.class ),
+                                          "p1" );
+        final boolean response1 = manager.requiresAuthentication( p1_1 );
+        assertFalse( response1 );
+
+        final Project p1_2 = new Project( root,
+                                          mock( Path.class ),
+                                          "p1" );
+        p1_2.getGroups().add( "admin" );
+        final boolean response2 = manager.requiresAuthentication( p1_2 );
+        assertTrue( response2 );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1193484

Project  needs to implement ```Cacheable``` to guarantee permissions are reloaded by ```RuntimeResourceManager``` following changes made with ```kie-cli-config```. 