### PR TITLE
Adjust dashbuilder dependencies

### DIFF
--- a/guvnor-webapp/pom.xml
+++ b/guvnor-webapp/pom.xml
@@ -56,6 +56,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3-extras</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -410,30 +415,7 @@
 
     <dependency>
       <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-common-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-dataset-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-dataset-shared</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-displayer-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-displayer-screen</artifactId>
+      <artifactId>dashbuilder-client-all</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -445,19 +427,7 @@
 
     <dependency>
       <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-renderer-default</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-renderer-google</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-widgets</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/guvnor-webapp/src/main/resources/org/guvnor/GuvnorWorkbench.gwt.xml
+++ b/guvnor-webapp/src/main/resources/org/guvnor/GuvnorWorkbench.gwt.xml
@@ -60,19 +60,8 @@
   <inherits name="org.uberfire.ext.wires.bayesian.network.BayesianNetworkClient"/>
 
   <!-- Dashbuilder dependencies -->
-  <inherits name="org.dashbuilder.CommonClient"/>
-
-  <inherits name="org.dashbuilder.DatasetAPI"/>
-  <inherits name="org.dashbuilder.DatasetShared"/>
-  <inherits name="org.dashbuilder.DatasetClient"/>
-
-  <inherits name="org.dashbuilder.DisplayerAPI"/>
-  <inherits name="org.dashbuilder.DisplayerClient"/>
-  <inherits name="org.dashbuilder.DisplayerScreen"/>
+  <inherits name="org.dashbuilder.DashbuilderClientAll"/>
   <inherits name="org.dashbuilder.DisplayerEditor"/>
-  <inherits name="org.dashbuilder.CommonValidations"/>
-
-  <inherits name="org.dashbuilder.renderer.DefaultRenderer"/>
   <inherits name="org.dashbuilder.renderer.GChartsRenderer"/>
   <inherits name="org.dashbuilder.renderer.LienzoChartsRenderer"/>
 


### PR DESCRIPTION
There was a missing dependency gwt-bootstrap3-extras. I've also simplified the dependency set.