### PR TITLE
GUVNOR-2293: Support by-passing NewResourceView from NewResourceHandler

### DIFF
--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanel.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanel.java
@@ -143,6 +143,11 @@ public class POMEditorPanel
     }
 
     @Override
+    public void setValidName( final boolean isValid ) {
+        view.setValidName( isValid );
+    }
+
+    @Override
     public void setValidGroupID( final boolean isValid ) {
         view.setValidGroupID( isValid );
     }

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelView.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelView.java
@@ -46,6 +46,8 @@ public interface POMEditorPanelView extends HasBusyIndicator,
 
         POM getPom();
 
+        void setValidName( boolean isValid );
+
         void setValidGroupID( boolean isValid );
 
         void setValidArtifactID( boolean isValid );
@@ -91,6 +93,8 @@ public interface POMEditorPanelView extends HasBusyIndicator,
     void enableGroupID();
 
     void enableVersion();
+
+    void setValidName( boolean isValid );
 
     void setValidGroupID( boolean isValid );
 

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelViewImpl.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelViewImpl.java
@@ -31,8 +31,11 @@ import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.common.services.project.client.resources.ProjectResources;
 import org.guvnor.common.services.project.model.GAV;
 import org.gwtbootstrap3.client.ui.FieldSet;
+import org.gwtbootstrap3.client.ui.FormGroup;
+import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -54,6 +57,12 @@ public class POMEditorPanelViewImpl
 
     @UiField
     TextBox pomNameTextBox;
+
+    @UiField
+    FormGroup pomNameGroup;
+
+    @UiField
+    HelpBlock pomNameHelpBlock;
 
     @UiField
     TextArea pomDescriptionTextArea;
@@ -185,6 +194,17 @@ public class POMEditorPanelViewImpl
     @Override
     public void hideBusyIndicator() {
         BusyPopup.close();
+    }
+
+    @Override
+    public void setValidName( final boolean isValid ) {
+        if ( isValid ) {
+            pomNameGroup.setValidationState( ValidationState.NONE );
+            pomNameHelpBlock.setText( "" );
+        } else {
+            pomNameGroup.setValidationState( ValidationState.ERROR );
+            pomNameHelpBlock.setText( ProjectResources.CONSTANTS.invalidName() );
+        }
     }
 
     @Override

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelViewImpl.ui.xml
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanelViewImpl.ui.xml
@@ -21,59 +21,58 @@
              xmlns:bootstrap='urn:import:org.gwtbootstrap3.client.ui'
              xmlns:guvnor='urn:import:org.guvnor.common.services.project.client'>
 
-    <ui:with field="i18n" type="org.guvnor.common.services.project.client.resources.i18n.ProjectConstants"/>
-    <ui:with field="resources" type="org.guvnor.common.services.project.client.resources.ProjectResources"/>
+  <ui:with field="i18n" type="org.guvnor.common.services.project.client.resources.i18n.ProjectConstants"/>
+  <ui:with field="resources" type="org.guvnor.common.services.project.client.resources.ProjectResources"/>
 
-    <gwt:HTMLPanel>
-        <bootstrap:Container fluid="true">
-            <bootstrap:Row>
-                <bootstrap:Column size="MD_12">
-                    <bootstrap:Form type="HORIZONTAL">
-                        <bootstrap:FieldSet>
+  <gwt:HTMLPanel>
+    <bootstrap:Container fluid="true">
+      <bootstrap:Row>
+        <bootstrap:Column size="MD_12">
+          <bootstrap:Form type="HORIZONTAL">
+            <bootstrap:FieldSet>
 
-                            <bootstrap:Legend>
-                                <ui:text from="{i18n.ProjectGeneralSettings}"/>
-                            </bootstrap:Legend>
+              <bootstrap:Legend>
+                <ui:text from="{i18n.ProjectGeneralSettings}"/>
+              </bootstrap:Legend>
 
-                            <bootstrap:FormGroup>
-                                <bootstrap:FormLabel text="{i18n.ProjectName}" addStyleNames="col-md-4"/>
-                                <bootstrap:Column size="MD_8">
-                                    <bootstrap:TextBox ui:field="pomNameTextBox" placeholder="{i18n.ProjectNamePlaceHolder}"/>
-                                </bootstrap:Column>
-                            </bootstrap:FormGroup>
-
-
-                            <bootstrap:FormGroup>
-                                <bootstrap:FormLabel text="{i18n.ProjectDescription}" addStyleNames="col-md-4"/>
-                                <bootstrap:Column size="MD_8">
-                                    <bootstrap:TextArea ui:field="pomDescriptionTextArea" placeholder="{i18n.ProjectDescriptionPlaceHolder}"/>
-                                </bootstrap:Column>
-                            </bootstrap:FormGroup>
-
-
-                        </bootstrap:FieldSet>
-
-                        <bootstrap:FieldSet ui:field="parentGavEditorFieldSet" visible="false">
-                            <bootstrap:Legend>
-                                <ui:text from="{i18n.ParentsGroupArtifactVersion}"/>
-                            </bootstrap:Legend>
-
-                            <bootstrap:Button ui:field="openProjectContext" addStyleNames="btn-mini" text="Open Project Context"/>
-                            <guvnor:GAVEditor ui:field="parentGavEditor"/>
-                        </bootstrap:FieldSet>
-
-                        <bootstrap:FieldSet>
-                            <bootstrap:Legend>
-                                <ui:text from="{i18n.GroupArtifactVersion}"/>
-                            </bootstrap:Legend>
-
-                            <guvnor:GAVEditor ui:field="gavEditor"/>
-                        </bootstrap:FieldSet>
-
-                    </bootstrap:Form>
+              <bootstrap:FormGroup ui:field="pomNameGroup">
+                <bootstrap:FormLabel text="{i18n.ProjectName}" addStyleNames="col-md-4"/>
+                <bootstrap:Column size="MD_8">
+                  <bootstrap:TextBox ui:field="pomNameTextBox" placeholder="{i18n.ProjectNamePlaceHolder}"/>
+                  <bootstrap:HelpBlock ui:field="pomNameHelpBlock"/>
                 </bootstrap:Column>
-            </bootstrap:Row>
-        </bootstrap:Container>
-    </gwt:HTMLPanel>
+              </bootstrap:FormGroup>
+
+              <bootstrap:FormGroup>
+                <bootstrap:FormLabel text="{i18n.ProjectDescription}" addStyleNames="col-md-4"/>
+                <bootstrap:Column size="MD_8">
+                  <bootstrap:TextArea ui:field="pomDescriptionTextArea" placeholder="{i18n.ProjectDescriptionPlaceHolder}"/>
+                </bootstrap:Column>
+              </bootstrap:FormGroup>
+
+            </bootstrap:FieldSet>
+
+            <bootstrap:FieldSet ui:field="parentGavEditorFieldSet" visible="false">
+              <bootstrap:Legend>
+                <ui:text from="{i18n.ParentsGroupArtifactVersion}"/>
+              </bootstrap:Legend>
+
+              <bootstrap:Button ui:field="openProjectContext" addStyleNames="btn-mini" text="Open Project Context"/>
+              <guvnor:GAVEditor ui:field="parentGavEditor"/>
+            </bootstrap:FieldSet>
+
+            <bootstrap:FieldSet>
+              <bootstrap:Legend>
+                <ui:text from="{i18n.GroupArtifactVersion}"/>
+              </bootstrap:Legend>
+
+              <guvnor:GAVEditor ui:field="gavEditor"/>
+            </bootstrap:FieldSet>
+
+          </bootstrap:Form>
+        </bootstrap:Column>
+      </bootstrap:Row>
+    </bootstrap:Container>
+  </gwt:HTMLPanel>
 
 </ui:UiBinder>

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/resources/ProjectResources.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/resources/ProjectResources.java
@@ -24,6 +24,6 @@ public interface ProjectResources
         extends
         ClientBundle {
 
-    public ProjectConstants CONSTANTS = GWT.create(ProjectConstants.class);
+    ProjectConstants CONSTANTS = GWT.create(ProjectConstants.class);
 
 }

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/resources/i18n/ProjectConstants.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/resources/i18n/ProjectConstants.java
@@ -71,4 +71,6 @@ public interface ProjectConstants
 
     String invalidVersion();
 
+    String invalidName();
+
 }

--- a/guvnor-project/guvnor-project-client/src/main/resources/org/guvnor/common/services/project/client/resources/i18n/ProjectConstants.properties
+++ b/guvnor-project/guvnor-project-client/src/main/resources/org/guvnor/common/services/project/client/resources/i18n/ProjectConstants.properties
@@ -139,3 +139,4 @@ ParentsGroupArtifactVersion=Parent''s Group, Artifact and Version
 invalidGroupId=Invalid Group ID format
 invalidArtifactId=Invalid Artifact ID format
 invalidVersion=Invalid Version format
+invalidName=Invalid name

--- a/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/POMEditorPanelTest.java
+++ b/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/POMEditorPanelTest.java
@@ -22,8 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.client.mvp.PlaceManager;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class POMEditorPanelTest {
 
@@ -34,46 +33,88 @@ public class POMEditorPanelTest {
 
     @Before
     public void setUp() throws Exception {
-        view = mock(POMEditorPanelView.class);
-        placeManager = mock(PlaceManager.class);
-        panel = new POMEditorPanel(view, placeManager);
+        view = mock( POMEditorPanelView.class );
+        placeManager = mock( PlaceManager.class );
+        panel = new POMEditorPanel( view, placeManager );
         presenter = panel;
     }
 
     @Test
     public void testLoad() throws Exception {
-        POM gavModel = createTestModel("group", "artifact", "1.1.1");
-        gavModel.setParent(new GAV("org.parent", "parent", "1.1.1"));
-        panel.setPOM(gavModel, false);
+        POM gavModel = createTestModel( "group", "artifact", "1.1.1" );
+        gavModel.setParent( new GAV( "org.parent", "parent", "1.1.1" ) );
+        panel.setPOM( gavModel, false );
 
-        verify(view).setGAV(gavModel.getGav());
-        verify(view).setTitleText("artifact");
-        verify(view).setParentGAV(gavModel.getParent());
-        verify(view).disableGroupID("");
-        verify(view).disableVersion("");
-        verify(view).showParentGAV();
+        verify( view ).setGAV( gavModel.getGav() );
+        verify( view ).setTitleText( "artifact" );
+        verify( view ).setParentGAV( gavModel.getParent() );
+        verify( view ).disableGroupID( "" );
+        verify( view ).disableVersion( "" );
+        verify( view ).showParentGAV();
 
-        gavModel = createTestModel("pomName", "pomDescription", "group", "artifact", "1.1.1");
-        panel.setPOM(gavModel, false);
+        gavModel = createTestModel( "pomName", "pomDescription", "group", "artifact", "1.1.1" );
+        panel.setPOM( gavModel, false );
 
-        verify(view).setName("pomName");
-        verify(view).setDescription("pomDescription");
-        verify(view).enableGroupID();
-        verify(view).enableVersion();
-        verify(view).hideParentGAV();
+        verify( view ).setName( "pomName" );
+        verify( view ).setDescription( "pomDescription" );
+        verify( view ).enableGroupID();
+        verify( view ).enableVersion();
+        verify( view ).hideParentGAV();
+    }
+
+    @Test
+    public void testProjectNameValidation() throws Exception {
+        panel.setValidName( true );
+        verify( view ).setValidName( true );
+
+        panel.setValidName( false );
+        verify( view ).setValidName( false );
+    }
+
+    @Test
+    public void testGroupIDValidation() throws Exception {
+        panel.setValidGroupID( true );
+        verify( view ).setValidGroupID( true );
+
+        panel.setValidGroupID( false );
+        verify( view ).setValidGroupID( false );
+    }
+
+    @Test
+    public void testArtifactIDValidation() throws Exception {
+        panel.setValidArtifactID( true );
+        verify( view ).setValidArtifactID( true );
+
+        panel.setValidArtifactID( false );
+        verify( view ).setValidArtifactID( false );
+    }
+
+    @Test
+    public void testVersionValidation() throws Exception {
+        panel.setValidVersion( true );
+        verify( view ).setValidVersion( true );
+
+        panel.setValidVersion( false );
+        verify( view ).setValidVersion( false );
     }
 
     @Test
     public void testOpenProjectContext() throws Exception {
         presenter.onOpenProjectContext();
-        verify(placeManager).goTo("repositoryStructureScreen");
+        verify( placeManager ).goTo( "repositoryStructureScreen" );
     }
 
-    private POM createTestModel(String group, String artifact, String version) {
-        return new POM(new GAV(group, artifact, version));
+    private POM createTestModel( String group,
+                                 String artifact,
+                                 String version ) {
+        return new POM( new GAV( group, artifact, version ) );
     }
 
-    private POM createTestModel(String name, String description, String group, String artifact, String version) {
-        return new POM(name, description, new GAV(group, artifact, version));
+    private POM createTestModel( String name,
+                                 String description,
+                                 String group,
+                                 String artifact,
+                                 String version ) {
+        return new POM( name, description, new GAV( group, artifact, version ) );
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2293

The "New Project" Wizard use a ```POMEditorPanel``` that did not validate the project name. By-passing the ```NewResourceView``` also removes the single point of validation of project name; so I've added support for project name validation in ```POMEditorPanel```. This panel was broken in essence anyway, as the User could change the project name in the Wizard to an invalid value. This is fixed.  