### PR TITLE
BZ-1296498 - Retrieve tag information only instead of full metadata

### DIFF
--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServerSideService.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServerSideService.java
@@ -16,6 +16,8 @@
 
 package org.guvnor.common.services.backend.metadata;
 
+import java.util.List;
+
 import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.uberfire.java.nio.file.Path;
@@ -24,5 +26,7 @@ public interface MetadataServerSideService
         extends MetadataService {
 
     Metadata getMetadata(Path resource);
+
+    List<String> getTags(Path resource);
 
 }

--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/MetadataService.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/MetadataService.java
@@ -16,6 +16,7 @@
 
 package org.guvnor.common.services.shared.metadata;
 
+import java.util.List;
 import java.util.Map;
 
 import org.guvnor.common.services.shared.metadata.model.Metadata;
@@ -29,6 +30,8 @@ import org.uberfire.backend.vfs.Path;
 public interface MetadataService {
 
     Metadata getMetadata( final Path resource );
+
+    List<String> getTags( final Path resource );
 
     Map<String, Object> configAttrs( final Map<String, Object> attrs,
                                      final Metadata metadata );

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
@@ -95,6 +95,22 @@ public class MetadataServiceImpl
     }
 
     @Override
+    public List<String> getTags(final Path pathToResource) {
+        return getTags(Paths.convert(pathToResource));
+    }
+
+    @Override
+    public List<String> getTags(org.uberfire.java.nio.file.Path path) {
+
+        OtherMetaView otherMetaView = ioService.getFileAttributeView(path, OtherMetaView.class);
+        if(otherMetaView != null) {
+           return otherMetaView.readAttributes().tags();
+        } else {
+           return new ArrayList<String>();
+        }
+    }
+
+    @Override
     public Map<String, Object> configAttrs(final Map<String, Object> _attrs,
                                            final Metadata metadata) {
         try {


### PR DESCRIPTION
Improve folder listing by retrieving only tag information, and not the complete metadata.