### PR TITLE
BZ1296498: [GSS] (6.2.z) Opening a repository takes a long time in BRMS 6.2

### DIFF
--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServerSideService.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServerSideService.java
@@ -16,6 +16,8 @@
 
 package org.guvnor.common.services.backend.metadata;
 
+import java.util.List;
+
 import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.uberfire.java.nio.file.Path;
@@ -23,6 +25,8 @@ import org.uberfire.java.nio.file.Path;
 public interface MetadataServerSideService
         extends MetadataService {
 
-    Metadata getMetadata(Path resource);
+    Metadata getMetadata(final Path resource);
+
+    List<String> getTags(final Path resource);
 
 }

--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/MetadataService.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/MetadataService.java
@@ -16,6 +16,7 @@
 
 package org.guvnor.common.services.shared.metadata;
 
+import java.util.List;
 import java.util.Map;
 
 import org.guvnor.common.services.shared.metadata.model.Metadata;
@@ -30,11 +31,12 @@ public interface MetadataService {
 
     Metadata getMetadata( final Path resource );
 
+    List<String> getTags( final Path resource );
+
     Map<String, Object> configAttrs( final Map<String, Object> attrs,
                                      final Metadata metadata );
 
-    Map<String, Object> setUpAttributes( Path path,
-                                         Metadata metadata );
-
+    Map<String, Object> setUpAttributes( final Path path,
+                                         final Metadata metadata );
 
 }

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
@@ -16,14 +16,11 @@
 
 package org.guvnor.common.services.backend.metadata;
 
-import static java.util.Collections.emptyList;
-import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -50,17 +47,20 @@ import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.attribute.FileTime;
 import org.uberfire.rpc.SessionInfo;
 
+import static java.util.Collections.*;
+import static org.uberfire.commons.validation.PortablePreconditions.*;
+
 @Service
 @ApplicationScoped
 public class MetadataServiceImpl
         implements MetadataServerSideService {
 
     private IOService ioService;
-    
+
     @Inject
     @Named("configIO")
     private IOService configIOService;
-    
+
     @Inject
     private SessionInfo sessionInfo;
 
@@ -68,45 +68,65 @@ public class MetadataServiceImpl
     }
 
     @Inject
-    public MetadataServiceImpl(@Named("ioStrategy") IOService ioService) {
+    public MetadataServiceImpl( @Named("ioStrategy") IOService ioService ) {
         this.ioService = ioService;
     }
 
     @Override
-    public Metadata getMetadata(final Path pathToResource) {
-        return getMetadata(Paths.convert(pathToResource));
+    public Metadata getMetadata( final Path pathToResource ) {
+        return getMetadata( Paths.convert( pathToResource ) );
     }
 
     @Override
-    public Metadata getMetadata(org.uberfire.java.nio.file.Path path) {
+    public Metadata getMetadata( org.uberfire.java.nio.file.Path path ) {
 
         try {
-            return new MetadataCreator(path,
-                                       configIOService,
-                                       sessionInfo,
-                                       ioService.getFileAttributeView(path, DublinCoreView.class),
-                                       ioService.getFileAttributeView(path, DiscussionView.class),
-                                       ioService.getFileAttributeView(path, OtherMetaView.class),
-                                       ioService.getFileAttributeView(path, VersionAttributeView.class)).create();
+            return new MetadataCreator( path,
+                                        configIOService,
+                                        sessionInfo,
+                                        ioService.getFileAttributeView( path, DublinCoreView.class ),
+                                        ioService.getFileAttributeView( path, DiscussionView.class ),
+                                        ioService.getFileAttributeView( path, OtherMetaView.class ),
+                                        ioService.getFileAttributeView( path, VersionAttributeView.class ) ).create();
 
-        } catch (Exception e) {
-            throw ExceptionUtilities.handleException(e);
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
         }
     }
 
     @Override
-    public Map<String, Object> configAttrs(final Map<String, Object> _attrs,
-                                           final Metadata metadata) {
+    public List<String> getTags( final Path resource ) {
+        checkNotNull( "resource",
+                      resource );
+        return getTags( Paths.convert( resource ) );
+    }
+
+    @Override
+    public List<String> getTags( final org.uberfire.java.nio.file.Path resource ) {
+        checkNotNull( "resource",
+                      resource );
+        final OtherMetaView otherMetaView = ioService.getFileAttributeView( resource,
+                                                                            OtherMetaView.class );
+        if ( otherMetaView != null ) {
+            return otherMetaView.readAttributes().tags();
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public Map<String, Object> configAttrs( final Map<String, Object> _attrs,
+                                            final Metadata metadata ) {
         try {
-            checkNotNull("_attrs", _attrs);
-            checkNotNull("metadata", metadata);
+            checkNotNull( "_attrs", _attrs );
+            checkNotNull( "metadata", metadata );
 
-            Map<String, Object> attrs = BasicFileAttributesUtil.cleanup(_attrs);
-            attrs = DublinCoreAttributesUtil.cleanup(attrs);
-            attrs = DiscussionAttributesUtil.cleanup(attrs);
-            attrs = OtherMetaAttributesUtil.cleanup(attrs);
+            Map<String, Object> attrs = BasicFileAttributesUtil.cleanup( _attrs );
+            attrs = DublinCoreAttributesUtil.cleanup( attrs );
+            attrs = DiscussionAttributesUtil.cleanup( attrs );
+            attrs = OtherMetaAttributesUtil.cleanup( attrs );
 
-            attrs.putAll(DiscussionAttributesUtil.toMap(
+            attrs.putAll( DiscussionAttributesUtil.toMap(
                     new DiscussionAttributes() {
                         @Override
                         public List<DiscussionRecord> discussion() {
@@ -157,9 +177,9 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*"));
+                    }, "*" ) );
 
-            attrs.putAll(OtherMetaAttributesUtil.toMap(
+            attrs.putAll( OtherMetaAttributesUtil.toMap(
                     new OtherMetaAttributes() {
                         @Override
                         public List<String> tags() {
@@ -210,9 +230,9 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*"));
+                    }, "*" ) );
 
-            attrs.putAll(DublinCoreAttributesUtil.toMap(
+            attrs.putAll( DublinCoreAttributesUtil.toMap(
                     new DublinCoreAttributes() {
 
                         @Override
@@ -227,15 +247,15 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> subjects() {
-                            return new ArrayList<String>(1) {{
-                                add(metadata.getSubject());
+                            return new ArrayList<String>( 1 ) {{
+                                add( metadata.getSubject() );
                             }};
                         }
 
                         @Override
                         public List<String> descriptions() {
-                            return new ArrayList<String>(1) {{
-                                add(metadata.getDescription());
+                            return new ArrayList<String>( 1 ) {{
+                                add( metadata.getDescription() );
                             }};
                         }
 
@@ -251,8 +271,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> types() {
-                            return new ArrayList<String>(1) {{
-                                add(metadata.getType());
+                            return new ArrayList<String>( 1 ) {{
+                                add( metadata.getType() );
                             }};
                         }
 
@@ -268,8 +288,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> sources() {
-                            return new ArrayList<String>(1) {{
-                                add(metadata.getExternalSource());
+                            return new ArrayList<String>( 1 ) {{
+                                add( metadata.getExternalSource() );
                             }};
                         }
 
@@ -280,8 +300,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> relations() {
-                            return new ArrayList<String>(1) {{
-                                add(metadata.getExternalRelation());
+                            return new ArrayList<String>( 1 ) {{
+                                add( metadata.getExternalRelation() );
                             }};
                         }
 
@@ -339,32 +359,32 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*"));
+                    }, "*" ) );
 
             return attrs;
 
-        } catch (Exception e) {
-            throw ExceptionUtilities.handleException(e);
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
         }
     }
 
     @Override
-    public Map<String, Object> setUpAttributes(final Path path,
-                                               final Metadata metadata) {
+    public Map<String, Object> setUpAttributes( final Path path,
+                                                final Metadata metadata ) {
         try {
             Map<String, Object> attributes;
             try {
-                attributes = ioService.readAttributes(Paths.convert(path));
-            } catch (final NoSuchFileException ex) {
+                attributes = ioService.readAttributes( Paths.convert( path ) );
+            } catch ( final NoSuchFileException ex ) {
                 attributes = new HashMap<String, Object>();
             }
-            if (metadata != null) {
-                attributes = configAttrs(attributes, metadata);
+            if ( metadata != null ) {
+                attributes = configAttrs( attributes, metadata );
             }
 
-            return BasicFileAttributesUtil.cleanup(attributes);
-        } catch (Exception e) {
-            throw ExceptionUtilities.handleException(e);
+            return BasicFileAttributesUtil.cleanup( attributes );
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
         }
     }
 

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataServiceImplTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataServiceImplTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.common.services.backend.metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataServiceImplTest {
+
+    private SimpleFileSystemProvider fileSystemProvider;
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private OtherMetaView otherMetaView;
+
+    private Path path;
+    private MetadataServerSideService service;
+
+    @Before
+    public void setUp() throws Exception {
+        fileSystemProvider = new SimpleFileSystemProvider();
+
+        //Ensure URLs use the default:// scheme
+        fileSystemProvider.forceAsDefault();
+
+        path = fileSystemProvider.getPath( this.getClass().getResource( "myfile.file" ).toURI() );
+
+        service = new MetadataServiceImpl( ioService );
+    }
+
+    @Test
+    public void testGetEmptyTagsNoOtherMetaView() {
+        final List<String> tags = service.getTags( path );
+
+        assertNotNull( tags );
+        assertEquals( 0,
+                      tags.size() );
+    }
+
+    @Test
+    public void testGetEmptyTags() {
+        when( otherMetaView.readAttributes() ).thenReturn( new OtherMetaAttributesMock() );
+        when( ioService.getFileAttributeView( path,
+                                              OtherMetaView.class ) ).thenReturn( otherMetaView );
+        final List<String> tags = service.getTags( path );
+
+        assertNotNull( tags );
+        assertEquals( 0,
+                      tags.size() );
+    }
+
+    @Test
+    public void testGetTags() {
+        when( otherMetaView.readAttributes() ).thenReturn( new OtherMetaAttributesMock() {
+
+            List<String> tags = new ArrayList<String>() {{
+                add( "tag1" );
+            }};
+
+            @Override
+            public List<String> tags() {
+                return tags;
+            }
+        } );
+        when( ioService.getFileAttributeView( path,
+                                              OtherMetaView.class ) ).thenReturn( otherMetaView );
+        final List<String> tags = service.getTags( path );
+
+        assertNotNull( tags );
+        assertEquals( 1,
+                      tags.size() );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1296498

The issue was introduced by BPMSPL-100 which added support for "tag filtering". This PR makes retrieval of tag meta-data optional only when "tag filtering" is enabled in the UI.