### PR TITLE
GUVNOR-2373: Modal for artifacts table in Project editor-Dependencies is too small for the content

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRequest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRequest.java
@@ -30,6 +30,8 @@ public class JarListPageRequest extends PageRequest {
 
     public static final String COLUMN_PATH = "org.guvnor.m2repo.model.path";
 
+    public static final String COLUMN_GAV = "org.guvnor.m2repo.model.gav";
+
     public static final String COLUMN_LAST_MODIFIED = "org.guvnor.m2repo.model.last.modified";
 
     private String filters;

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRow.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRow.java
@@ -18,6 +18,7 @@ package org.guvnor.m2repo.model;
 
 import java.util.Date;
 
+import org.guvnor.common.services.project.model.GAV;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.paging.AbstractPageRow;
 
@@ -29,7 +30,7 @@ public class JarListPageRow extends AbstractPageRow {
 
     private String name;
     private String path;
-    //private GAV gav;
+    private GAV gav;
     private Date lastModified;
 
     public String getName() {
@@ -48,13 +49,13 @@ public class JarListPageRow extends AbstractPageRow {
         this.path = path;
     }
 
-/*    public GAV getGav() {
+    public GAV getGav() {
         return gav;
     }
 
-    public void setGav(GAV gav) {
+    public void setGav( GAV gav ) {
         this.gav = gav;
-    }*/
+    }
 
     public Date getLastModified() {
         return lastModified;

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
@@ -16,15 +16,22 @@
 
 package org.guvnor.m2repo.backend.server;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.drools.compiler.kproject.xml.MinimalPomParser;
+import org.drools.compiler.kproject.xml.PomModel;
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
@@ -78,30 +85,84 @@ public class M2RepoServiceImpl implements M2RepoService,
 
     @Override
     public PageResponse<JarListPageRow> listArtifacts( final JarListPageRequest pageRequest ) {
-        final Collection<File> files = repository.listFiles( pageRequest.getFilters(),
-                                                             pageRequest.getDataSourceName(),
-                                                             pageRequest.isAscending() );
+        //Get unsorted files matching filter
+        final String filters = pageRequest.getFilters();
+        final String dataSourceName = pageRequest.getDataSourceName();
+        final boolean isAscending = pageRequest.isAscending();
+        final Collection<File> files = repository.listFiles( filters );
 
-        final PageResponse<JarListPageRow> response = new PageResponse<JarListPageRow>();
+        //Convert files to JarListPageRow
         final List<JarListPageRow> jarPageRowList = new ArrayList<JarListPageRow>();
-
-        int i = 0;
         for ( File file : files ) {
-            if ( i >= pageRequest.getStartRowIndex() + pageRequest.getPageSize() ) {
-                break;
-            }
-            if ( i >= pageRequest.getStartRowIndex() ) {
-                JarListPageRow jarListPageRow = new JarListPageRow();
-                jarListPageRow.setName( file.getName() );
-                jarListPageRow.setPath( getJarPath( file.getPath(),
-                                                    File.separator ) );
-                jarListPageRow.setLastModified( new Date( file.lastModified() ) );
-                jarPageRowList.add( jarListPageRow );
-            }
-            i++;
+            JarListPageRow jarListPageRow = new JarListPageRow();
+            jarListPageRow.setName( file.getName() );
+            jarListPageRow.setPath( getJarPath( file.getPath(),
+                                                File.separator ) );
+            jarListPageRow.setGav( getGAV( jarListPageRow.getPath() ) );
+            jarListPageRow.setLastModified( new Date( file.lastModified() ) );
+            jarPageRowList.add( jarListPageRow );
         }
 
-        response.setPageRowList( jarPageRowList );
+        //Sort JarListPageRow entries, if required
+        if ( dataSourceName != null ) {
+            final int order = ( isAscending ? 1 : -1 );
+            if ( dataSourceName.equals( JarListPageRequest.COLUMN_NAME ) ) {
+                Collections.sort( jarPageRowList,
+                                  new Comparator<JarListPageRow>() {
+                                      @Override
+                                      public int compare( final JarListPageRow o1,
+                                                          final JarListPageRow o2 ) {
+                                          return o1.getName().compareTo( o2.getName() ) * order;
+                                      }
+                                  } );
+
+            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_PATH ) ) {
+                Collections.sort( jarPageRowList,
+                                  new Comparator<JarListPageRow>() {
+                                      @Override
+                                      public int compare( final JarListPageRow o1,
+                                                          final JarListPageRow o2 ) {
+                                          return o1.getPath().compareTo( o2.getPath() ) * order;
+                                      }
+                                  } );
+
+            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_GAV ) ) {
+                Collections.sort( jarPageRowList,
+                                  new Comparator<JarListPageRow>() {
+                                      @Override
+                                      public int compare( final JarListPageRow o1,
+                                                          final JarListPageRow o2 ) {
+                                          final GAV gav1 = o1.getGav();
+                                          final GAV gav2 = o2.getGav();
+                                          return gav1.toString().compareToIgnoreCase( gav2.toString() ) * order;
+                                      }
+                                  } );
+
+            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_LAST_MODIFIED ) ) {
+                Collections.sort( jarPageRowList,
+                                  new Comparator<JarListPageRow>() {
+                                      @Override
+                                      public int compare( final JarListPageRow o1,
+                                                          final JarListPageRow o2 ) {
+                                          final Long ft1 = o1.getLastModified().getTime();
+                                          final Long ft2 = o2.getLastModified().getTime();
+                                          return ft1.compareTo( ft2 ) * order;
+                                      }
+                                  } );
+            }
+        }
+
+        //Copy request "page" of entries to response
+        final Integer pageSize = pageRequest.getPageSize();
+        final int startRowIndex = pageRequest.getStartRowIndex();
+        final int endRowIndex = ( pageSize == null ? jarPageRowList.size() : startRowIndex + pageSize );
+        final List<JarListPageRow> responsePageRowList = new ArrayList<JarListPageRow>();
+        for ( int i = startRowIndex; i < endRowIndex; i++ ) {
+            responsePageRowList.add( jarPageRowList.get( i ) );
+        }
+
+        final PageResponse<JarListPageRow> response = new PageResponse<JarListPageRow>();
+        response.setPageRowList( responsePageRowList );
         response.setStartRowIndex( pageRequest.getStartRowIndex() );
         response.setTotalRowSize( files.size() );
         response.setTotalRowSizeExact( true );
@@ -119,6 +180,35 @@ public class M2RepoServiceImpl implements M2RepoService,
         jarPath = jarPath.replaceAll( "\\" + separator,
                                       "/" );
         return jarPath;
+    }
+
+    GAV getGAV( final String path ) {
+        GAV gav = null;
+        InputStream is = null;
+        try {
+            final String pom = getPomText( path );
+            is = new ByteArrayInputStream( pom.getBytes( Charset.forName( "UTF-8" ) ) );
+            final PomModel model = MinimalPomParser.parse( path,
+                                                           is );
+            gav = new GAV( model.getReleaseId().getGroupId(),
+                           model.getReleaseId().getArtifactId(),
+                           model.getReleaseId().getVersion() );
+
+        } catch ( RuntimeException rte ) {
+            //RuntimeException is thrown by MinimalPomParser for any Exception..
+            gav = new GAV( "<undetermined>",
+                           "<undetermined>",
+                           "<undetermined>" );
+        } finally {
+            if ( is != null ) {
+                try {
+                    is.close();
+                } catch ( IOException ioe ) {
+                    //Swallow
+                }
+            }
+        }
+        return gav;
     }
 
     /**

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryServiceImplTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryServiceImplTest.java
@@ -45,12 +45,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.paging.PageResponse;
 
-import static org.junit.Assert.*;
 import static org.guvnor.m2repo.model.HTMLFileManagerFields.*;
+import static org.junit.Assert.*;
 
-public class M2RepositoryTest {
+public class M2RepositoryServiceImplTest {
 
-    private static final Logger log = LoggerFactory.getLogger( M2RepositoryTest.class );
+    private static final Logger log = LoggerFactory.getLogger( M2RepositoryServiceImplTest.class );
     private static GAV gavBackend;
     private static GAV gavBackend1;
     private static GAV gavBackend2;
@@ -64,20 +64,20 @@ public class M2RepositoryTest {
     @BeforeClass
     public static void setupClass() {
         gavBackend = new GAV( "org.kie.guvnor",
-                "guvnor-m2repo-editor-backend",
-                "0.0.1-SNAPSHOT" );
+                              "guvnor-m2repo-editor-backend",
+                              "0.0.1-SNAPSHOT" );
 
         gavBackend1 = new GAV( "org.kie.guvnor",
-                "guvnor-m2repo-editor-backend1",
-                "0.0.1-SNAPSHOT" );
+                               "guvnor-m2repo-editor-backend1",
+                               "0.0.1-SNAPSHOT" );
 
         gavBackend2 = new GAV( "org.kie.guvnor",
-                "guvnor-m2repo-editor-backend2",
-                "0.0.1-SNAPSHOT" );
+                               "guvnor-m2repo-editor-backend2",
+                               "0.0.1-SNAPSHOT" );
 
         gavArquillian = new GAV( "org.jboss.arquillian.core",
-                "arquillian-core-api",
-                "1.0.2.Final" );
+                                 "arquillian-core-api",
+                                 "1.0.2.Final" );
     }
 
     @Before
@@ -85,9 +85,9 @@ public class M2RepositoryTest {
         log.info( "Deleting existing Repositories instance.." );
 
         File dir = new File( "repositories" );
-        log.info("DELETING test repo: " + dir.getAbsolutePath());
-        deleteDir(dir);
-        log.info("TEST repo was deleted.");
+        log.info( "DELETING test repo: " + dir.getAbsolutePath() );
+        deleteDir( dir );
+        log.info( "TEST repo was deleted." );
 
         repo = new GuvnorM2Repository();
         repo.init();
@@ -96,17 +96,17 @@ public class M2RepositoryTest {
         service = new M2RepoServiceImpl();
         java.lang.reflect.Field repositoryField = M2RepoServiceImpl.class.getDeclaredField( "repository" );
         repositoryField.setAccessible( true );
-        repositoryField.set(service, repo );
+        repositoryField.set( service, repo );
 
         //Make private method accessible for testing
         helper = new HttpPostHelper();
         helperMethod = HttpPostHelper.class.getDeclaredMethod( "upload", FormData.class );
-        helperMethod.setAccessible(true);
+        helperMethod.setAccessible( true );
 
         //Set the repository service created above in the HttpPostHelper
         java.lang.reflect.Field m2RepoServiceField = HttpPostHelper.class.getDeclaredField( "m2RepoService" );
         m2RepoServiceField.setAccessible( true );
-        m2RepoServiceField.set(helper, service);
+        m2RepoServiceField.set( helper, service );
     }
 
     @AfterClass
@@ -174,8 +174,8 @@ public class M2RepositoryTest {
     @Test
     public void testDeployPom() throws Exception {
         InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" );
-        repo.deployPom(is,
-                gavBackend);
+        repo.deployPom( is,
+                        gavBackend );
 
         Collection<File> files = repo.listFiles();
 
@@ -230,7 +230,7 @@ public class M2RepositoryTest {
         boolean found1 = false;
         Collection<File> files = repo.listFiles( "1.0.2" );
         final String VERSION_NUMBER_SEARCH_FILTER = "arquillian-core-api-1.0.2";
-        for (File file : files ) {
+        for ( File file : files ) {
             String fileName = file.getName();
             if ( fileName.startsWith( VERSION_NUMBER_SEARCH_FILTER ) && fileName.endsWith( ".jar" ) ) {
                 found1 = true;
@@ -272,7 +272,7 @@ public class M2RepositoryTest {
         FormData uploadItem = new FormData();
         FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-with-pom.jar",
                                           this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-with-pom.jar" ) );
-        uploadItem.setFile(file);
+        uploadItem.setFile( file );
 
         assert ( helperMethod.invoke( helper,
                                       uploadItem ).equals( UPLOAD_OK ) );
@@ -283,7 +283,7 @@ public class M2RepositoryTest {
         FormData uploadItem = new FormData();
         FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-with-pom.kjar",
                                           this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-with-pom.jar" ) );
-        uploadItem.setFile(file);
+        uploadItem.setFile( file );
 
         assert ( helperMethod.invoke( helper,
                                       uploadItem ).equals( UPLOAD_OK ) );
@@ -295,7 +295,7 @@ public class M2RepositoryTest {
         uploadItem.setGav( gavBackend );
         FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-without-pom.jar",
                                           this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" ) );
-        uploadItem.setFile(file);
+        uploadItem.setFile( file );
 
         assert ( helperMethod.invoke( helper,
                                       uploadItem ).equals( UPLOAD_OK ) );
@@ -307,7 +307,7 @@ public class M2RepositoryTest {
         uploadItem.setGav( gavBackend );
         FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test.kjar",
                                           this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" ) );
-        uploadItem.setFile(file);
+        uploadItem.setFile( file );
 
         assert ( helperMethod.invoke( helper,
                                       uploadItem ).equals( UPLOAD_OK ) );
@@ -317,7 +317,6 @@ public class M2RepositoryTest {
      * Verify that
      * {@link M2RepoServiceImpl#listArtifacts(org.guvnor.m2repo.model.JarListPageRequest) M2RepoServiceImpl.listArtifacts()}
      * returns correct PageResponse.
-     *
      * @throws java.lang.Exception
      */
     @Test
@@ -331,7 +330,7 @@ public class M2RepositoryTest {
         }
         // Create a mock repository to make the test independent on any project deployment
         GuvnorM2Repository mockRepo = Mockito.mock( GuvnorM2Repository.class );
-        Mockito.when( mockRepo.listFiles( Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean() ) )
+        Mockito.when( mockRepo.listFiles( Mockito.anyString() ) )
                 .thenReturn( artifacts );
 
         // Create a shell M2RepoService with injected mock M2Repository
@@ -359,12 +358,12 @@ public class M2RepositoryTest {
         FormData uploadItem = new FormData();
         FileItem file = new MockFileItem( "pom.xml",
                                           this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" ) );
-        uploadItem.setFile(file);
+        uploadItem.setFile( file );
 
         assert ( helperMethod.invoke( helper,
                                       uploadItem ).equals( UPLOAD_OK ) );
 
-        assertFilesCount(null, null, false, 1);
+        assertFilesCount( null, null, false, 1 );
     }
 
     @Test
@@ -373,12 +372,15 @@ public class M2RepositoryTest {
         deployArtifact( gavBackend2 );
 
         //Sort by Name ascending
-        List<File> files = assertFilesCount(null, JarListPageRequest.COLUMN_NAME, true, 4);
-
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_NAME,
+                                                                        true,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
         final String fileName0 = files.get( 0 ).getName();
-        final String fileName2 = files.get(2).getName();
-        assertTrue(fileName0.startsWith("guvnor-m2repo-editor-backend1"));
-        assertTrue(fileName2.startsWith("guvnor-m2repo-editor-backend2"));
+        final String fileName2 = files.get( 2 ).getName();
+        assertTrue( fileName0.startsWith( "guvnor-m2repo-editor-backend1" ) );
+        assertTrue( fileName2.startsWith( "guvnor-m2repo-editor-backend2" ) );
     }
 
     @Test
@@ -387,12 +389,15 @@ public class M2RepositoryTest {
         deployArtifact( gavBackend2 );
 
         //Sort by Name descending
-        List<File> files = assertFilesCount(null, JarListPageRequest.COLUMN_NAME, false, 4);
-
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_NAME,
+                                                                        false,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
         final String fileName0 = files.get( 0 ).getName();
         final String fileName2 = files.get( 2 ).getName();
-        assertTrue( fileName0.startsWith("guvnor-m2repo-editor-backend2"));
-        assertTrue(fileName2.startsWith( "guvnor-m2repo-editor-backend1" ) );
+        assertTrue( fileName0.startsWith( "guvnor-m2repo-editor-backend2" ) );
+        assertTrue( fileName2.startsWith( "guvnor-m2repo-editor-backend1" ) );
     }
 
     @Test
@@ -401,12 +406,15 @@ public class M2RepositoryTest {
         deployArtifact( gavBackend2 );
 
         //Sort by Path ascending
-        List<File> files = assertFilesCount(null, JarListPageRequest.COLUMN_PATH, true, 4);
-
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_PATH,
+                                                                        true,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
         final String filePath0 = files.get( 0 ).getPath();
         final String filePath2 = files.get( 2 ).getPath();
-        assertTrue( filePath0.contains("guvnor-m2repo-editor-backend1"));
-        assertTrue(filePath2.contains("guvnor-m2repo-editor-backend2") );
+        assertTrue( filePath0.contains( "guvnor-m2repo-editor-backend1" ) );
+        assertTrue( filePath2.contains( "guvnor-m2repo-editor-backend2" ) );
     }
 
     @Test
@@ -415,8 +423,11 @@ public class M2RepositoryTest {
         deployArtifact( gavBackend2 );
 
         //Sort by Path descending
-        List<File> files = assertFilesCount(null, JarListPageRequest.COLUMN_PATH, false, 4);
-
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_PATH,
+                                                                        false,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
         final String filePath0 = files.get( 0 ).getPath();
         final String filePath2 = files.get( 2 ).getPath();
         assertTrue( filePath0.contains( "guvnor-m2repo-editor-backend2" ) );
@@ -424,20 +435,61 @@ public class M2RepositoryTest {
     }
 
     @Test
+    public void testListFilesWithSortOnGavAscending() throws Exception {
+        deployArtifact( gavBackend1 );
+        deployArtifact( gavBackend2 );
+
+        //Sort by Name ascending
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_GAV,
+                                                                        true,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
+        final GAV gav0 = files.get( 0 ).getGav();
+        final GAV gav2 = files.get( 2 ).getGav();
+        assertEquals( "guvnor-m2repo-editor-backend1",
+                      gav0.getArtifactId() );
+        assertEquals( "guvnor-m2repo-editor-backend2",
+                      gav2.getArtifactId() );
+    }
+
+    @Test
+    public void testListFilesWithSortOnGavDescending() throws Exception {
+        deployArtifact( gavBackend1 );
+        deployArtifact( gavBackend2 );
+
+        //Sort by Name descending
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_GAV,
+                                                                        false,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
+        final GAV gav0 = files.get( 0 ).getGav();
+        final GAV gav2 = files.get( 2 ).getGav();
+        assertEquals( "guvnor-m2repo-editor-backend2",
+                      gav0.getArtifactId() );
+        assertEquals( "guvnor-m2repo-editor-backend1",
+                      gav2.getArtifactId() );
+    }
+
+    @Test
     public void testListFilesWithSortOnLastModifiedAscending() throws Exception {
         deployArtifact( gavBackend1 );
 
         //Wait a bit before deploying other file (to ensure different Last Modified times)
-        Thread.sleep(2000);
+        Thread.sleep( 2000 );
 
         //This installs a JAR and a POM
         deployArtifact( gavBackend2 );
 
         //Sort by Last Modified ascending
-        List<File> files = assertFilesCount( null, JarListPageRequest.COLUMN_LAST_MODIFIED, true, 4 );
-
-        final Long fileTime0 = files.get( 0 ).lastModified();
-        final Long fileTime2 = files.get( 2 ).lastModified();
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_LAST_MODIFIED,
+                                                                        true,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
+        final Long fileTime0 = files.get( 0 ).getLastModified().getTime();
+        final Long fileTime2 = files.get( 2 ).getLastModified().getTime();
         assertTrue( fileTime0.compareTo( fileTime2 ) < 0 );
     }
 
@@ -451,10 +503,13 @@ public class M2RepositoryTest {
         deployArtifact( gavBackend2 );
 
         //Sort by Last Modified descending
-        List<File> files = assertFilesCount( null, JarListPageRequest.COLUMN_LAST_MODIFIED, false, 4 );
-
-        final Long fileTime0 = files.get( 0 ).lastModified();
-        final Long fileTime2 = files.get( 2 ).lastModified();
+        final PageResponse<JarListPageRow> response = assertFilesCount( null,
+                                                                        JarListPageRequest.COLUMN_LAST_MODIFIED,
+                                                                        false,
+                                                                        4 );
+        final List<JarListPageRow> files = response.getPageRowList();
+        final Long fileTime0 = files.get( 0 ).getLastModified().getTime();
+        final Long fileTime2 = files.get( 2 ).getLastModified().getTime();
         assertTrue( fileTime0.compareTo( fileTime2 ) > 0 );
     }
 
@@ -464,27 +519,36 @@ public class M2RepositoryTest {
 
         //This installs a POM
         GAV gavBackendParent = new GAV( "org.kie.guvnor",
-                       "guvnor-m2repo-editor-backend-parent",
-                       "0.0.1-SNAPSHOT" );
+                                        "guvnor-m2repo-editor-backend-parent",
+                                        "0.0.1-SNAPSHOT" );
         InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" );
         repo.deployPom( is,
                         gavBackendParent );
 
-        assertFilesCount(null, null, false, 3);
+        assertFilesCount( null, null, false, 3 );
     }
 
-    private List<File> assertFilesCount(String filters, String dataSource, boolean ascending, int filesCount) {
-        List<File> files = repo.listFiles( filters, dataSource, ascending );
-        assertEquals(filesCount, files.size());
-        return files;
+    private PageResponse<JarListPageRow> assertFilesCount( final String filters,
+                                                           final String dataSourceName,
+                                                           final boolean isAscending,
+                                                           final int filesCount ) {
+        final JarListPageRequest request = new JarListPageRequest( 0,
+                                                                   null,
+                                                                   filters,
+                                                                   dataSourceName,
+                                                                   isAscending );
+        final PageResponse<JarListPageRow> response = service.listArtifacts( request );
+        assertEquals( filesCount,
+                      response.getPageRowList().size() );
+        return response;
     }
 
-    private void deployArtifact( GAV gav) {
+    private void deployArtifact( GAV gav ) {
         //This installs a JAR and a POM
         InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" );
         repo.deployArtifact( is,
-                gav,
-                false );
+                             gav,
+                             false );
     }
 
     //Create a mock FileItem setting an InputStream to test with

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/pom.xml
@@ -55,6 +55,10 @@
 
     <dependency>
       <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-project-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
       <artifactId>guvnor-m2repo-editor-api</artifactId>
     </dependency>
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/editor/MavenRepositoryPagedJarTable.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/editor/MavenRepositoryPagedJarTable.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
@@ -53,7 +54,27 @@ public class MavenRepositoryPagedJarTable
 
     @PostConstruct
     public void init() {
-        //If the current user is not an Administrator do not include the download button
+        // Add "View KJAR's pom" button column
+        final Column<JarListPageRow, String> openColumn = new Column<JarListPageRow, String>( new ButtonCell( ButtonSize.EXTRA_SMALL ) ) {
+            @Override
+            public String getValue( JarListPageRow row ) {
+                return M2RepoEditorConstants.INSTANCE.Open();
+            }
+        };
+        openColumn.setFieldUpdater( new FieldUpdater<JarListPageRow, String>() {
+            @Override
+            public void update( int index,
+                                JarListPageRow row,
+                                String value ) {
+                presenter.onOpenPom( row.getPath() );
+            }
+        } );
+        presenter.getView().addColumn( openColumn,
+                                       M2RepoEditorConstants.INSTANCE.Open(),
+                                       100.0,
+                                       Style.Unit.PX );
+
+        //If the current user is an Administrator include the download button
         if ( identity.getRoles().contains( new RoleImpl( "admin" ) ) ) {
             final Column<JarListPageRow, String> downloadColumn = new Column<JarListPageRow, String>( new ButtonCell( ButtonSize.EXTRA_SMALL ) ) {
                 public String getValue( JarListPageRow row ) {
@@ -72,7 +93,9 @@ public class MavenRepositoryPagedJarTable
             } );
 
             presenter.getView().addColumn( downloadColumn,
-                                           M2RepoEditorConstants.INSTANCE.Download() );
+                                           M2RepoEditorConstants.INSTANCE.Download(),
+                                           100.0,
+                                           Style.Unit.PX );
         }
 
         initWidget( presenter.getView().asWidget() );

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.java
@@ -94,6 +94,8 @@ public interface M2RepoEditorConstants
 
     String Path();
 
+    String GAV();
+
     String LastModified();
 
     String Open();

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/widgets/ArtifactListView.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/widgets/ArtifactListView.java
@@ -15,6 +15,7 @@
  */
 package org.guvnor.m2repo.client.widgets;
 
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortList;
 import com.google.gwt.view.client.HasData;
@@ -27,6 +28,21 @@ public interface ArtifactListView extends UberView<ArtifactListPresenter> {
 
     void addColumn( final Column<JarListPageRow, ?> column,
                     final String caption );
+
+    void addColumn( final Column<JarListPageRow, ?> column,
+                    final String caption,
+                    final boolean visible );
+
+    void addColumn( final Column<JarListPageRow, ?> column,
+                    final String caption,
+                    final double width,
+                    final Style.Unit unit );
+
+    void addColumn( final Column<JarListPageRow, ?> column,
+                    final String caption,
+                    final boolean visible,
+                    final double width,
+                    final Style.Unit unit );
 
     void showPom( String pomText );
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/widgets/ArtifactListViewImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/widgets/ArtifactListViewImpl.java
@@ -19,9 +19,9 @@ import java.util.Date;
 import javax.enterprise.context.Dependent;
 
 import com.google.gwt.cell.client.DateCell;
-import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.cell.client.TextCell;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -35,8 +35,6 @@ import org.guvnor.m2repo.client.editor.JarDetailPopup;
 import org.guvnor.m2repo.client.resources.i18n.M2RepoEditorConstants;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
-import org.gwtbootstrap3.client.ui.constants.ButtonSize;
-import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
 import org.uberfire.ext.widgets.common.client.tables.PagedTable;
 
 @Dependent
@@ -45,11 +43,12 @@ public class ArtifactListViewImpl extends Composite implements ArtifactListView 
     interface ArtifactListViewImplWidgetBinder
             extends
             UiBinder<Widget, ArtifactListViewImpl> {
+
     }
 
     private ArtifactListViewImplWidgetBinder uiBinder = GWT.create( ArtifactListViewImplWidgetBinder.class );
 
-    @UiField( provided = true )
+    @UiField(provided = true)
     final PagedTable<JarListPageRow> dataGrid = new PagedTable<JarListPageRow>();
 
     protected ArtifactListPresenter presenter;
@@ -65,19 +64,19 @@ public class ArtifactListViewImpl extends Composite implements ArtifactListView 
         };
         nameColumn.setSortable( true );
         nameColumn.setDataStoreName( JarListPageRequest.COLUMN_NAME );
-        dataGrid.addColumn( nameColumn,
-                            M2RepoEditorConstants.INSTANCE.Name() );
+        addColumn( nameColumn,
+                   M2RepoEditorConstants.INSTANCE.Name() );
 
-        final Column<JarListPageRow, String> pathColumn = new Column<JarListPageRow, String>( new TextCell() ) {
+        final Column<JarListPageRow, String> gavColumn = new Column<JarListPageRow, String>( new TextCell() ) {
             @Override
             public String getValue( JarListPageRow row ) {
-                return row.getPath();
+                return row.getGav().toString();
             }
         };
-        pathColumn.setSortable( true );
-        pathColumn.setDataStoreName( JarListPageRequest.COLUMN_PATH );
-        dataGrid.addColumn( pathColumn,
-                            M2RepoEditorConstants.INSTANCE.Path() );
+        gavColumn.setSortable( true );
+        gavColumn.setDataStoreName( JarListPageRequest.COLUMN_GAV );
+        addColumn( gavColumn,
+                   M2RepoEditorConstants.INSTANCE.GAV() );
 
         final Column<JarListPageRow, Date> lastModifiedColumn = new Column<JarListPageRow, Date>( new DateCell( DateTimeFormat.getFormat( DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM ) ) ) {
             @Override
@@ -87,26 +86,9 @@ public class ArtifactListViewImpl extends Composite implements ArtifactListView 
         };
         lastModifiedColumn.setSortable( true );
         lastModifiedColumn.setDataStoreName( JarListPageRequest.COLUMN_LAST_MODIFIED );
-        dataGrid.addColumn( lastModifiedColumn,
-                            M2RepoEditorConstants.INSTANCE.LastModified() );
-
-        // Add "View kjar detail" button column
-        final Column<JarListPageRow, String> openColumn = new Column<JarListPageRow, String>( new ButtonCell( ButtonSize.EXTRA_SMALL ) ) {
-            @Override
-            public String getValue( JarListPageRow row ) {
-                return M2RepoEditorConstants.INSTANCE.Open();
-            }
-        };
-        openColumn.setFieldUpdater( new FieldUpdater<JarListPageRow, String>() {
-            @Override
-            public void update( int index,
-                                JarListPageRow row,
-                                String value ) {
-                presenter.onOpenPom( row.getPath() );
-            }
-        } );
-        dataGrid.addColumn( openColumn,
-                            M2RepoEditorConstants.INSTANCE.Open() );
+        addColumn( lastModifiedColumn,
+                   M2RepoEditorConstants.INSTANCE.LastModified(),
+                   false );
 
         dataGrid.addColumnSortHandler( new ColumnSortEvent.AsyncHandler( dataGrid ) );
 
@@ -128,6 +110,41 @@ public class ArtifactListViewImpl extends Composite implements ArtifactListView 
                            final String caption ) {
         dataGrid.addColumn( column,
                             caption );
+    }
+
+    @Override
+    public void addColumn( final Column<JarListPageRow, ?> column,
+                           final String caption,
+                           final boolean visible ) {
+        dataGrid.addColumn( column,
+                            caption,
+                            visible );
+    }
+
+    @Override
+    public void addColumn( final Column<JarListPageRow, ?> column,
+                           final String caption,
+                           final double width,
+                           final Style.Unit unit ) {
+        dataGrid.addColumn( column,
+                            caption );
+        dataGrid.setColumnWidth( column,
+                                 width,
+                                 unit );
+    }
+
+    @Override
+    public void addColumn( final Column<JarListPageRow, ?> column,
+                           final String caption,
+                           final boolean visible,
+                           final double width,
+                           final Style.Unit unit ) {
+        dataGrid.addColumn( column,
+                            caption,
+                            visible );
+        dataGrid.setColumnWidth( column,
+                                 width,
+                                 unit );
     }
 
     @Override

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorClient.gwt.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorClient.gwt.xml
@@ -29,6 +29,7 @@
 
   <inherits name="org.uberfire.UberfireClient"/>
   <inherits name="org.guvnor.m2repo.GuvnorM2RepoEditorAPI"/>
+  <inherits name="org.guvnor.common.services.project.GuvnorProjectAPI"/>
 
   <inherits name='org.uberfire.ext.widgets.common.UberfireWidgetsCommons'/>
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.properties
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.properties
@@ -47,6 +47,7 @@ AreYouSureYouWantToDeleteTheseItems=Are you sure you want to delete these jars?
 JarDetails=JAR details
 M2RepositoryContent=M2 Repository Content
 Path=Path
+GAV=GAV
 LastModified=Last Modified
 Open=Open
 Download=Download


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2373

This PR adds sorting by ```GAV```, moves sorting itself to ```M2RepoServiceImpl``` and adjusts the columns shown in ```ArtifactListViewImpl``` (as re-use in ```kie-wb-common``` needs to show different columns).