### PR TITLE
BPMSPL-252: [GSS-RFE] Ability to check duplicate of ReleaseId (GroupId, ArtifactId and Version) with existing projects. Updates following QE feedback.

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/command/MavenDeployProjectCommand.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/command/MavenDeployProjectCommand.java
@@ -29,7 +29,10 @@ import org.guvnor.asset.management.social.ProjectDeployedEvent;
 import org.guvnor.common.services.project.builder.model.BuildMessage;
 import org.guvnor.common.services.project.builder.model.BuildResults;
 import org.guvnor.common.services.project.builder.service.BuildService;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
 import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.GAVAlreadyExistsException;
 import org.guvnor.common.services.project.service.ProjectService;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.messageconsole.events.MessageUtils;
@@ -45,62 +48,78 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 
 public class MavenDeployProjectCommand extends AbstractCommand {
-	
-	private static final Logger logger = LoggerFactory.getLogger(MavenDeployProjectCommand.class);
 
-	@Override
-	public ExecutionResults execute(CommandContext ctx) throws Exception {
-		try {
+    private static final Logger logger = LoggerFactory.getLogger( MavenDeployProjectCommand.class );
+
+    @Override
+    public ExecutionResults execute( CommandContext ctx ) throws Exception {
+        try {
             ExecutionResults executionResults = new ExecutionResults();
             String deployOutcome = "UNKNOWN";
-            String uri = (String) getParameter(ctx, "Uri");
-            String branchToBuild = (String) getParameter(ctx, "BranchToBuild");
+            String uri = (String) getParameter( ctx,
+                                                "Uri" );
+            String branchToBuild = (String) getParameter( ctx,
+                                                          "BranchToBuild" );
 
-            String projectUri = "default://"+branchToBuild+"@"+uri;
-            String gav = (String) getParameter(ctx, "GAV");
-            String[] gavElements = gav.split(":");
+            String projectUri = "default://" + branchToBuild + "@" + uri;
+            String gav = (String) getParameter( ctx,
+                                                "GAV" );
+            String[] gavElements = gav.split( ":" );
 
-            BeanManager beanManager = CDIUtils.lookUpBeanManager(ctx);
-            logger.debug("BeanManager " + beanManager);
+            BeanManager beanManager = CDIUtils.lookUpBeanManager( ctx );
+            logger.debug( "BeanManager " + beanManager );
 
-            BuildService builder = CDIUtils.createBean(BuildService.class, beanManager);
-            logger.debug("Builder " + builder);
+            BuildService builder = CDIUtils.createBean( BuildService.class,
+                                                        beanManager );
+            logger.debug( "Builder " + builder );
 
-            IOService ioService = CDIUtils.createBean(IOService.class, beanManager, new NamedLiteral("ioStrategy"));
-            logger.debug("IoService " + ioService);
+            IOService ioService = CDIUtils.createBean( IOService.class,
+                                                       beanManager,
+                                                       new NamedLiteral( "ioStrategy" ) );
+            logger.debug( "IoService " + ioService );
 
-            RepositoryService repositoryService = CDIUtils.createBean( RepositoryService.class, beanManager );
+            RepositoryService repositoryService = CDIUtils.createBean( RepositoryService.class,
+                                                                       beanManager );
             logger.debug( "RepositoryService " + repositoryService );
 
-            ProjectDeployedEvent event = getSocialEvent( (String)ctx.getData( "_ProcessName" ),
-                    uri,
-                    gavElements,
-                    repositoryService);
+            ProjectDeployedEvent event = getSocialEvent( (String) ctx.getData( "_ProcessName" ),
+                                                         uri,
+                                                         gavElements,
+                                                         repositoryService );
 
-            if (ioService != null) {
-                Path projectPath  = ioService.get(URI.create(projectUri));
-                logger.debug("Project path is " + projectPath);
+            if ( ioService != null ) {
+                Path projectPath = ioService.get( URI.create( projectUri ) );
+                logger.debug( "Project path is " + projectPath );
 
-                ProjectService projectService = CDIUtils.createBean(new TypeLiteral<ProjectService<?>>() {}.getType(), beanManager);
-                Project project = projectService.resolveProject(Paths.convert(projectPath));
+                ProjectService projectService = CDIUtils.createBean( new TypeLiteral<ProjectService<?>>() {
+                }.getType(),
+                                                                     beanManager );
+                Project project = projectService.resolveProject( Paths.convert( projectPath ) );
 
-                // suppress handlers to avoid auto deploys to runtime
-                BuildResults results = builder.buildAndDeploy(project, true);
+                BuildResults results = new BuildResults( project.getPom().getGav() );
+                try {
+                    // suppress handlers to avoid auto deploys to runtime
+                    results = builder.buildAndDeploy( project,
+                                                      true );
+
+                } catch ( GAVAlreadyExistsException gae ) {
+                    results.addAllBuildMessages( convertToBuildMessages( gae ) );
+                }
 
                 // dump to debug if enabled
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Errors " + results.getErrorMessages().size());
-                    logger.debug("Warnings " + results.getWarningMessages().size());
-                    logger.debug("Info " + results.getInformationMessages().size());
+                if ( logger.isDebugEnabled() ) {
+                    logger.debug( "Errors " + results.getErrorMessages().size() );
+                    logger.debug( "Warnings " + results.getWarningMessages().size() );
+                    logger.debug( "Info " + results.getInformationMessages().size() );
                 }
-                if (results.getErrorMessages().isEmpty()) {
+                if ( results.getErrorMessages().isEmpty() ) {
                     deployOutcome = "SUCCESSFUL";
                 } else {
                     deployOutcome = "FAILURE";
                     for ( BuildMessage message : results.getMessages() ) {
                         event.addError( message.getText() );
                         if ( logger.isDebugEnabled() ) {
-                            logger.debug("Error " + message.getText());
+                            logger.debug( "Error " + message.getText() );
                         }
                     }
 
@@ -109,59 +128,78 @@ public class MavenDeployProjectCommand extends AbstractCommand {
                     List<SystemMessage> messageList = new ArrayList<SystemMessage>();
 
                     SystemMessage buildOutcomeMsg = new SystemMessage();
-                    buildOutcomeMsg.setLevel(Level.ERROR);
-                    buildOutcomeMsg.setText("Maven install process failed for project " + project.getProjectName());
+                    buildOutcomeMsg.setLevel( Level.ERROR );
+                    buildOutcomeMsg.setText( "Maven install process failed for project " + project.getProjectName() );
                     buildOutcomeMsg.setMessageType( MessageUtils.BUILD_SYSTEM_MESSAGE );
-                    messageList.add(buildOutcomeMsg);
+                    messageList.add( buildOutcomeMsg );
 
-                    beanManager.fireEvent(publishMessage);
+                    beanManager.fireEvent( publishMessage );
                 }
-                executionResults.setData("Errors", results.getErrorMessages());
-                executionResults.setData("Warnings", results.getWarningMessages());
-                executionResults.setData("Info", results.getInformationMessages());
-                executionResults.setData("GAV", results.getGAV().toString());
+                executionResults.setData( "Errors", results.getErrorMessages() );
+                executionResults.setData( "Warnings", results.getWarningMessages() );
+                executionResults.setData( "Info", results.getInformationMessages() );
+                executionResults.setData( "GAV", results.getGAV().toString() );
 
                 beanManager.fireEvent( event );
             }
-            executionResults.setData("MavenDeployOutcome", deployOutcome);
-
+            executionResults.setData( "MavenDeployOutcome", deployOutcome );
 
             return executionResults;
-        } catch (Throwable e) {
-            throw new AssetManagementRuntimeException(e);
+        } catch ( Throwable e ) {
+            throw new AssetManagementRuntimeException( e );
         }
-	}
+    }
 
-    private ProjectDeployedEvent getSocialEvent(String processName,
-            String uriParam,
-            String[] gavElements,
-            RepositoryService repositoryService) {
+    private List<BuildMessage> convertToBuildMessages( final GAVAlreadyExistsException gae ) {
+        final GAV gav = gae.getGAV();
+        final List<BuildMessage> messages = new ArrayList<BuildMessage>();
+        for ( MavenRepositoryMetadata md : gae.getRepositories() ) {
+            messages.add( convertToBuildMessage( gav,
+                                                 md ) );
+        }
+        return messages;
+    }
 
+    private BuildMessage convertToBuildMessage( final GAV gav,
+                                                final MavenRepositoryMetadata md ) {
+        final BuildMessage message = new BuildMessage();
+        message.setLevel( Level.ERROR );
+        message.setText( "Artifact '" + gav.toString() + "' was found at '" + md.getId() + " " + md.getUrl() + " " + md.getSource() + "'." );
+        return message;
+    }
+
+    private ProjectDeployedEvent getSocialEvent( String processName,
+                                                 String uriParam,
+                                                 String[] gavElements,
+                                                 RepositoryService repositoryService ) {
         String repository = null;
         String projectName = null;
         String repositoryURI = null;
 
         if ( uriParam != null && uriParam.indexOf( "/" ) > 0 ) {
-            repository = uriParam.substring( 0, uriParam.indexOf( "/" ) );
-            projectName = uriParam.substring( uriParam.indexOf( "/" )+1, uriParam.length() );
-            repositoryURI = DataUtils.readRepositoryURI( repositoryService, repository );
+            repository = uriParam.substring( 0,
+                                             uriParam.indexOf( "/" ) );
+            projectName = uriParam.substring( uriParam.indexOf( "/" ) + 1,
+                                              uriParam.length() );
+            repositoryURI = DataUtils.readRepositoryURI( repositoryService,
+                                                         repository );
         }
 
-        ProjectDeployedEvent event = new ProjectDeployedEvent(processName,
-                repository,
-                repositoryURI,
-                "system",
-                System.currentTimeMillis());
+        ProjectDeployedEvent event = new ProjectDeployedEvent( processName,
+                                                               repository,
+                                                               repositoryURI,
+                                                               "system",
+                                                               System.currentTimeMillis() );
 
         event.setDeployType( ProjectDeployedEvent.DeployType.MAVEN );
         event.setProjectName( projectName );
-        if ( gavElements != null && gavElements.length == 3) {
-            event.setGroupId( gavElements[0] );
-            event.setArtifactId( gavElements[1] );
-            event.setVersion( gavElements[2] );
+        if ( gavElements != null && gavElements.length == 3 ) {
+            event.setGroupId( gavElements[ 0 ] );
+            event.setArtifactId( gavElements[ 1 ] );
+            event.setVersion( gavElements[ 2 ] );
         }
 
         return event;
     }
-	
+
 }

--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
@@ -71,7 +71,7 @@ public class RepositoryStructureServiceImpl
     private GuvnorM2Repository m2service;
     private CommentedOptionFactory optionsFactory;
     private Event<RepositoryUpdatedEvent> repositoryUpdatedEvent;
-    private ProjectRepositoryResolver<? extends Project> repositoryResolver;
+    private ProjectRepositoryResolver repositoryResolver;
 
     public RepositoryStructureServiceImpl() {
         //Zero-parameter constructor for CDI proxies
@@ -86,7 +86,7 @@ public class RepositoryStructureServiceImpl
                                            final GuvnorM2Repository m2service,
                                            final CommentedOptionFactory optionsFactory,
                                            final Event<RepositoryUpdatedEvent> repositoryUpdatedEvent,
-                                           final ProjectRepositoryResolver<? extends Project> repositoryResolver ) {
+                                           final ProjectRepositoryResolver repositoryResolver ) {
         this.ioService = ioService;
         this.pomService = pomService;
         this.projectService = projectService;

--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/test/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImplTest.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/test/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImplTest.java
@@ -38,6 +38,7 @@ import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryService;
 import org.guvnor.structure.repositories.RepositoryUpdatedEvent;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -83,9 +84,20 @@ public class RepositoryStructureServiceImplTest {
     };
 
     @Mock
-    private ProjectRepositoryResolver<Project> repositoryResolver;
+    private ProjectRepositoryResolver repositoryResolver;
 
     private RepositoryStructureService service;
+
+    @BeforeClass
+    public static void setupSystemProperties() {
+        //These are not needed for the tests
+        System.setProperty( "org.uberfire.nio.git.daemon.enabled",
+                            "false" );
+        System.setProperty( "org.uberfire.nio.git.ssh.enabled",
+                            "false" );
+        System.setProperty( "org.uberfire.sys.repo.monitor.disabled",
+                            "true" );
+    }
 
     @Before
     public void setup() {

--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/java/org/guvnor/asset/management/client/i18n/Constants.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/java/org/guvnor/asset/management/client/i18n/Constants.java
@@ -290,6 +290,8 @@ public interface Constants extends Messages {
 
     String IsRequired();
 
+    String ValidatingProjectGAV();
+
     String CreatingRepository();
 
     String RepoCreationSuccess();

--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/resources/org/guvnor/asset/management/client/i18n/Constants.properties
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-client/src/main/resources/org/guvnor/asset/management/client/i18n/Constants.properties
@@ -151,6 +151,7 @@ MultiModuleHelpInline=Integrate multiple projects to create a larger application
 ProjectBranches=Project Branches:
 ConfigureBranches=Automatically Configure Branches (master/dev/release)
 IsRequired=* is required
+ValidatingProjectGAV=Validating Project GAV
 CreatingRepository=Creating Repository
 RepoCreationSuccess=Repository was successfully created
 InitializingRepository=Initializing Repository

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/GAV.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/GAV.java
@@ -79,6 +79,10 @@ public class GAV implements Serializable {
         return equals( o );
     }
 
+    public boolean isSnapshot() {
+        return this.version.endsWith( "-SNAPSHOT" );
+    }
+
     @Override
     public boolean equals( Object o ) {
         if ( this == o ) {

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/ProjectRepositories.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/ProjectRepositories.java
@@ -39,6 +39,18 @@ public class ProjectRepositories {
         return repositories;
     }
 
+    public MavenRepositoryMetadata[] filterByIncluded() {
+        final Set<MavenRepositoryMetadata> filter = new HashSet<MavenRepositoryMetadata>();
+        for ( ProjectRepositories.ProjectRepository pr : repositories ) {
+            if ( pr.isIncluded() ) {
+                filter.add( pr.getMetadata() );
+            }
+        }
+        final MavenRepositoryMetadata[] aFilter = new MavenRepositoryMetadata[ filter.size() ];
+        filter.toArray( aFilter );
+        return aFilter;
+    }
+
     @Portable
     public static class ProjectRepository {
 

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectRepositoryResolver.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectRepositoryResolver.java
@@ -27,7 +27,9 @@ import org.jboss.errai.bus.server.annotations.Remote;
  *
  */
 @Remote
-public interface ProjectRepositoryResolver<T extends Project> {
+public interface ProjectRepositoryResolver {
+
+    String CONFLICTING_GAV_CHECK_DISABLED = "org.guvnor.project.gav.check.disabled";
 
     /**
      * Get a collection of Repositories a Project will resolve artifacts against. The list will include
@@ -43,7 +45,7 @@ public interface ProjectRepositoryResolver<T extends Project> {
      * @param project The Project to retrieve Repository information.
      * @return
      */
-    Set<MavenRepositoryMetadata> getRemoteRepositoriesMetaData( final T project );
+    Set<MavenRepositoryMetadata> getRemoteRepositoriesMetaData( final Project project );
 
     /**
      * Get a collection of Repositories that a given GAV resolve against.
@@ -62,7 +64,7 @@ public interface ProjectRepositoryResolver<T extends Project> {
      * @return A collection of RemoteRepositories that resolve the provided GAV; i.e. an Artifact already exists for the GAV
      */
     Set<MavenRepositoryMetadata> getRepositoriesResolvingArtifact( final GAV gav,
-                                                                   final T project,
+                                                                   final Project project,
                                                                    final MavenRepositoryMetadata... filter );
 
     /**

--- a/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/GAVCheckPreferencesLoader.java
+++ b/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/GAVCheckPreferencesLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.guvnor.common.services.backend.preferences.ApplicationPreferencesLoader;
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Make the "org.guvnor.project.gav.check.disabled" System Property available client-side.
+ */
+@ApplicationScoped
+public class GAVCheckPreferencesLoader implements ApplicationPreferencesLoader {
+
+    private static final Logger log = LoggerFactory.getLogger( GAVCheckPreferencesLoader.class );
+
+    @Override
+    public Map<String, String> load() {
+        final Map<String, String> preferences = new HashMap<String, String>();
+        addSystemProperty( preferences,
+                           ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+
+        return preferences;
+    }
+
+    private void addSystemProperty( final Map<String, String> preferences,
+                                    final String key ) {
+        final String value = System.getProperty( key );
+        if ( value != null ) {
+            log.info( "Setting preference '" + key + "' to '" + value + "'." );
+            preferences.put( key,
+                             value );
+        }
+    }
+}

--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/AbstractDeleteProjectObserverBridgeTest.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/AbstractDeleteProjectObserverBridgeTest.java
@@ -39,11 +39,11 @@ import org.uberfire.workbench.events.ResourceUpdated;
 
 import static org.mockito.Mockito.*;
 
-public class DeleteProjectObserverBridgeTest {
+public class AbstractDeleteProjectObserverBridgeTest {
 
-    private DeleteProjectObserverBridge bridge;
+    private AbstractDeleteProjectObserverBridge bridge;
     private IOService ioService;
-    private ProjectFactory<? extends Project> projectFactory;
+    private ProjectFactory<Project> projectFactory;
     private Event<DeleteProjectEvent> deleteProjectEvent;
     private SessionInfo sessionInfo = mock( SessionInfo.class );
 
@@ -54,9 +54,13 @@ public class DeleteProjectObserverBridgeTest {
         projectFactory = mock( ProjectFactory.class );
         deleteProjectEvent = mock( Event.class );
 
-        bridge = new DeleteProjectObserverBridge( ioService,
-                                                  projectFactory,
-                                                  deleteProjectEvent );
+        bridge = new AbstractDeleteProjectObserverBridge<Project>( ioService,
+                                                                   deleteProjectEvent ) {
+            @Override
+            protected Project getProject( final org.uberfire.java.nio.file.Path path ) {
+                return projectFactory.simpleProjectInstance( path );
+            }
+        };
     }
 
     @Test

--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/GAVCheckPreferencesLoaderTest.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/GAVCheckPreferencesLoaderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server;
+
+import java.util.Map;
+
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GAVCheckPreferencesLoaderTest {
+
+    private String oldPropertyValue;
+
+    private GAVCheckPreferencesLoader loader;
+
+    @Before
+    public void setup() {
+        oldPropertyValue = System.getProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+        loader = new GAVCheckPreferencesLoader();
+    }
+
+    @After
+    public void reset() {
+        if ( oldPropertyValue != null ) {
+            System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                oldPropertyValue );
+        } else {
+            System.clearProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+        }
+    }
+
+    @Test
+    public void testWithoutSystemProperty() {
+        final Map<String, String> results = loader.load();
+        assertNotNull( results );
+        assertEquals( 0,
+                      results.size() );
+    }
+
+    @Test
+    public void testWithSystemPropertyTrue() {
+        System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                            "true" );
+        final Map<String, String> results = loader.load();
+        assertNotNull( results );
+        assertEquals( 1,
+                      results.size() );
+        assertTrue( Boolean.parseBoolean( results.get( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED ) ) );
+    }
+
+    @Test
+    public void testWithSystemPropertyFalse() {
+        System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                            "false" );
+        final Map<String, String> results = loader.load();
+        assertNotNull( results );
+        assertEquals( 1,
+                      results.size() );
+        assertFalse( Boolean.parseBoolean( results.get( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED ) ) );
+    }
+
+    @Test
+    public void testWithSystemPropertyDuffValue() {
+        System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                            "cheese" );
+        final Map<String, String> results = loader.load();
+        assertNotNull( results );
+        assertEquals( 1,
+                      results.size() );
+        assertFalse( Boolean.parseBoolean( results.get( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED ) ) );
+    }
+
+}

--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/ProjectRepositoryResolverImplTest.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/ProjectRepositoryResolverImplTest.java
@@ -29,6 +29,7 @@ import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
 import org.guvnor.common.services.project.model.MavenRepositorySource;
 import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -47,15 +48,26 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RepositoryResolverTest {
+public class ProjectRepositoryResolverImplTest {
 
     @Mock
     private IOService ioService;
 
-    private RepositoryResolver<Project> service;
+    private ProjectRepositoryResolverImpl service;
 
     private static java.nio.file.Path m2Folder = null;
     private static java.nio.file.Path settingsXmlPath = null;
+
+    @BeforeClass
+    public static void setupSystemProperties() {
+        //These are not needed for the tests
+        System.setProperty( "org.uberfire.nio.git.daemon.enabled",
+                            "false" );
+        System.setProperty( "org.uberfire.nio.git.ssh.enabled",
+                            "false" );
+        System.setProperty( "org.uberfire.sys.repo.monitor.disabled",
+                            "true" );
+    }
 
     @BeforeClass
     public static void setupMavenRepository() {
@@ -71,7 +83,7 @@ public class RepositoryResolverTest {
 
     @Before
     public void setup() {
-        service = new RepositoryResolver<Project>( ioService ){};
+        service = new ProjectRepositoryResolverImpl( ioService );
     }
 
     @AfterClass
@@ -1252,6 +1264,171 @@ public class RepositoryResolverTest {
             if ( oldSettingsXmlPath != null ) {
                 System.setProperty( "kie.maven.settings.custom",
                                     oldSettingsXmlPath );
+            }
+        }
+    }
+
+    @Test
+    public void testGetRepositoriesResolvingArtifact_Disabled1() {
+        final String oldSettingsXmlPath = System.getProperty( "kie.maven.settings.custom" );
+        final String oldConflictingGavCheckSetting = System.getProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+
+        try {
+            final String pomXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                    "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+                    "  <modelVersion>4.0.0</modelVersion>\n" +
+                    "  <groupId>org.guvnor</groupId>\n" +
+                    "  <artifactId>test</artifactId>\n" +
+                    "  <version>0.0.1</version>\n" +
+                    "</project>";
+
+            final GAV gav = new GAV( "org.guvnor",
+                                     "test",
+                                     "0.0.1" );
+
+            System.setProperty( "kie.maven.settings.custom",
+                                settingsXmlPath.toString() );
+            System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                "true" );
+
+            //Re-instantiate service to pick-up System Property
+            service = new ProjectRepositoryResolverImpl( ioService );
+
+            final InputStream pomStream = new ByteArrayInputStream( pomXml.getBytes( StandardCharsets.UTF_8 ) );
+            final MavenProject mavenProject = MavenProjectLoader.parseMavenPom( pomStream );
+            installArtifact( mavenProject,
+                             pomXml );
+
+            //Without being disabled this would return one resolved (LOCAL) Repository
+            final Set<MavenRepositoryMetadata> metadata = service.getRepositoriesResolvingArtifact( gav );
+            assertNotNull( metadata );
+            assertEquals( 0,
+                          metadata.size() );
+
+        } finally {
+            if ( oldSettingsXmlPath != null ) {
+                System.setProperty( "kie.maven.settings.custom",
+                                    oldSettingsXmlPath );
+            }
+            if ( oldConflictingGavCheckSetting != null ) {
+                System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                    oldConflictingGavCheckSetting );
+            } else {
+                System.clearProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+            }
+        }
+    }
+
+    @Test
+    public void testGetRepositoriesResolvingArtifact_Disabled2() {
+        final Project project = mock( Project.class );
+        final org.uberfire.backend.vfs.Path vfsPomXmlPath = mock( org.uberfire.backend.vfs.Path.class );
+        final String oldSettingsXmlPath = System.getProperty( "kie.maven.settings.custom" );
+        final String oldConflictingGavCheckSetting = System.getProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+
+        try {
+            final String pomXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                    "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+                    "  <modelVersion>4.0.0</modelVersion>\n" +
+                    "  <groupId>org.guvnor</groupId>\n" +
+                    "  <artifactId>test</artifactId>\n" +
+                    "  <version>0.0.1</version>\n" +
+                    "</project>";
+
+            final GAV gav = new GAV( "org.guvnor",
+                                     "test",
+                                     "0.0.1" );
+
+            when( project.getPomXMLPath() ).thenReturn( vfsPomXmlPath );
+            when( vfsPomXmlPath.toURI() ).thenReturn( "default://p0/pom.xml" );
+            when( ioService.readAllString( any( Path.class ) ) ).thenReturn( pomXml );
+
+            System.setProperty( "kie.maven.settings.custom",
+                                settingsXmlPath.toString() );
+            System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                "true" );
+
+            //Re-instantiate service to pick-up System Property
+            service = new ProjectRepositoryResolverImpl( ioService );
+
+            final InputStream pomStream = new ByteArrayInputStream( pomXml.getBytes( StandardCharsets.UTF_8 ) );
+            final MavenProject mavenProject = MavenProjectLoader.parseMavenPom( pomStream );
+            installArtifact( mavenProject,
+                             pomXml );
+
+            //Without being disabled this would return one resolved (LOCAL) Repository
+            final Set<MavenRepositoryMetadata> metadata = service.getRepositoriesResolvingArtifact( gav,
+                                                                                                    project );
+            assertNotNull( metadata );
+            assertEquals( 0,
+                          metadata.size() );
+
+        } finally {
+            if ( oldSettingsXmlPath != null ) {
+                System.setProperty( "kie.maven.settings.custom",
+                                    oldSettingsXmlPath );
+            }
+            if ( oldConflictingGavCheckSetting != null ) {
+                System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                    oldConflictingGavCheckSetting );
+            } else {
+                System.clearProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+            }
+        }
+    }
+
+    @Test
+    public void testGetRepositoriesResolvingArtifact_Disabled3() {
+        final Project project = mock( Project.class );
+        final org.uberfire.backend.vfs.Path vfsPomXmlPath = mock( org.uberfire.backend.vfs.Path.class );
+        final String oldSettingsXmlPath = System.getProperty( "kie.maven.settings.custom" );
+        final String oldConflictingGavCheckSetting = System.getProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
+
+        try {
+            final String pomXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                    "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+                    "  <modelVersion>4.0.0</modelVersion>\n" +
+                    "  <groupId>org.guvnor</groupId>\n" +
+                    "  <artifactId>test</artifactId>\n" +
+                    "  <version>0.0.1</version>\n" +
+                    "</project>";
+
+            when( project.getPomXMLPath() ).thenReturn( vfsPomXmlPath );
+            when( vfsPomXmlPath.toURI() ).thenReturn( "default://p0/pom.xml" );
+            when( ioService.readAllString( any( Path.class ) ) ).thenReturn( pomXml );
+
+            System.setProperty( "kie.maven.settings.custom",
+                                settingsXmlPath.toString() );
+            System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                "true" );
+
+            //Re-instantiate service to pick-up System Property
+            service = new ProjectRepositoryResolverImpl( ioService );
+
+            final InputStream pomStream = new ByteArrayInputStream( pomXml.getBytes( StandardCharsets.UTF_8 ) );
+            final MavenProject mavenProject = MavenProjectLoader.parseMavenPom( pomStream );
+            installArtifact( mavenProject,
+                             pomXml );
+
+            //Without being disabled this would return one resolved (LOCAL) Repository
+            final Set<MavenRepositoryMetadata> metadata = service.getRepositoriesResolvingArtifact( pomXml );
+            assertNotNull( metadata );
+            assertEquals( 0,
+                          metadata.size() );
+
+        } finally {
+            if ( oldSettingsXmlPath != null ) {
+                System.setProperty( "kie.maven.settings.custom",
+                                    oldSettingsXmlPath );
+            }
+            if ( oldConflictingGavCheckSetting != null ) {
+                System.setProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED,
+                                    oldConflictingGavCheckSetting );
+            } else {
+                System.clearProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
             }
         }
     }

--- a/guvnor-webapp/src/main/java/org/guvnor/server/DeleteProjectObserverBridge.java
+++ b/guvnor-webapp/src/main/java/org/guvnor/server/DeleteProjectObserverBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.server;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.common.services.project.backend.server.AbstractDeleteProjectObserverBridge;
+import org.guvnor.common.services.project.events.DeleteProjectEvent;
+import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.project.ProjectFactory;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.workbench.events.ResourceBatchChangesEvent;
+import org.uberfire.workbench.events.ResourceDeletedEvent;
+
+/**
+ * CDI implementation for guvnor's Workbench
+ */
+@ApplicationScoped
+public class DeleteProjectObserverBridge extends AbstractDeleteProjectObserverBridge<Project> {
+
+    private ProjectFactory<Project> projectFactory;
+
+    public DeleteProjectObserverBridge() {
+        //Zero-arg constructor for CDI proxying
+    }
+
+    @Inject
+    public DeleteProjectObserverBridge( final @Named("ioStrategy") IOService ioService,
+                                        final Event<DeleteProjectEvent> deleteProjectEvent,
+                                        final ProjectFactory<Project> projectFactory ) {
+        super( ioService,
+               deleteProjectEvent );
+        this.projectFactory = PortablePreconditions.checkNotNull( "projectFactory",
+                                                                  projectFactory );
+    }
+
+    public void onBatchResourceChanges( final @Observes ResourceDeletedEvent event ) {
+        super.onBatchResourceChanges( event );
+    }
+
+    public void onBatchResourceChanges( final @Observes ResourceBatchChangesEvent resourceBatchChangesEvent ) {
+        super.onBatchResourceChanges( resourceBatchChangesEvent );
+    }
+
+    @Override
+    protected Project getProject( final Path path ) {
+        return projectFactory.simpleProjectInstance( path );
+    }
+
+}

--- a/guvnor-webapp/src/main/java/org/guvnor/server/ProjectRepositoriesServiceImpl.java
+++ b/guvnor-webapp/src/main/java/org/guvnor/server/ProjectRepositoriesServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.server;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
+import org.guvnor.common.services.project.backend.server.AbstractProjectRepositoriesServiceImpl;
+import org.guvnor.common.services.project.backend.server.ProjectRepositoriesContentHandler;
+import org.guvnor.common.services.project.backend.server.ResourceResolver;
+import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+import org.jboss.errai.bus.server.annotations.Service;
+import org.uberfire.io.IOService;
+
+/**
+ * CDI implementation for guvnor's Workbench
+ */
+@Service
+@ApplicationScoped
+public class ProjectRepositoriesServiceImpl extends AbstractProjectRepositoriesServiceImpl<Project> {
+
+    protected ResourceResolver<Project> resourceResolver;
+
+    public ProjectRepositoriesServiceImpl() {
+        //WELD proxy
+    }
+
+    @Inject
+    public ProjectRepositoriesServiceImpl( final @Named("ioStrategy") IOService ioService,
+                                           final ProjectRepositoryResolver repositoryResolver,
+                                           final ResourceResolver<Project> resourceResolver,
+                                           final ProjectRepositoriesContentHandler contentHandler,
+                                           final CommentedOptionFactory commentedOptionFactory ) {
+        super( ioService,
+               repositoryResolver,
+               contentHandler,
+               commentedOptionFactory );
+        this.resourceResolver = resourceResolver;
+    }
+
+    @Override
+    protected Project getProject( final org.uberfire.backend.vfs.Path path ) {
+        return resourceResolver.resolveProject( path );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/BPMSPL-252

This PR includes updates requested by QE following their testing. It also moves a couple of WebBeans (WAS) unfriendly ```<? extends Project>``` from ```guvnor``` to ```<KieProject>``` in ```kie-wb-common```.

Branch name retained (yes, I know @psiroky it's not ideal) to be consistent and support reconciliation of all changes made for the feature.