### PR TITLE
GUVNOR-2399: Errors retrieving LockInfo

### DIFF
--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataCreator.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataCreator.java
@@ -16,8 +16,6 @@
 
 package org.guvnor.common.services.backend.metadata;
 
-import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -36,8 +34,11 @@ import org.uberfire.java.nio.base.version.VersionAttributeView;
 import org.uberfire.java.nio.base.version.VersionAttributes;
 import org.uberfire.java.nio.base.version.VersionHistory;
 import org.uberfire.java.nio.base.version.VersionRecord;
+import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.rpc.SessionInfo;
+
+import static org.uberfire.commons.validation.PortablePreconditions.*;
 
 public class MetadataCreator {
 
@@ -49,47 +50,47 @@ public class MetadataCreator {
     private final IOService configIOService;
     private final SessionInfo sessionInfo;
 
-    public MetadataCreator(Path path,
-                           IOService configIOService,
-                           SessionInfo sessionInfo,
-                           DublinCoreView dublinCoreView,
-                           DiscussionView discussionView,
-                           OtherMetaView otherMetaView,
-                           VersionAttributeView versionAttributeView) {
-        this.path = checkNotNull("path", path);
-        this.configIOService = checkNotNull("configIOService", configIOService);
-        this.sessionInfo = checkNotNull("sessionInfo", sessionInfo);
-        this.dublinCoreView = checkNotNull("dublinCoreView", dublinCoreView);
-        this.discussView = checkNotNull("discussionView", discussionView);
-        this.otherMetaView = checkNotNull("otherMetaView", otherMetaView);
-        this.versionAttributeView = checkNotNull("versionAttributeView", versionAttributeView);
+    public MetadataCreator( Path path,
+                            IOService configIOService,
+                            SessionInfo sessionInfo,
+                            DublinCoreView dublinCoreView,
+                            DiscussionView discussionView,
+                            OtherMetaView otherMetaView,
+                            VersionAttributeView versionAttributeView ) {
+        this.path = checkNotNull( "path", path );
+        this.configIOService = checkNotNull( "configIOService", configIOService );
+        this.sessionInfo = checkNotNull( "sessionInfo", sessionInfo );
+        this.dublinCoreView = checkNotNull( "dublinCoreView", dublinCoreView );
+        this.discussView = checkNotNull( "discussionView", discussionView );
+        this.otherMetaView = checkNotNull( "otherMetaView", otherMetaView );
+        this.versionAttributeView = checkNotNull( "versionAttributeView", versionAttributeView );
     }
 
     public Metadata create() {
         return MetadataBuilder.newMetadata()
-                .withPath(Paths.convert(path))
-                .withRealPath(Paths.convert(path.toRealPath()))
-                .withCheckinComment(getCheckinComment())
-                .withLastContributor(getLastContributor())
-                .withCreator(getCreator())
-                .withLastModified(getLastModified())
-                .withDateCreated(getDateCreated())
-                .withSubject(getSubject())
-                .withType(getType())
-                .withExternalRelation(getExternalRelation())
-                .withExternalSource(getExternalSource())
-                .withDescription(getDescription())
+                .withPath( Paths.convert( path ) )
+                .withRealPath( Paths.convert( path.toRealPath() ) )
+                .withCheckinComment( getCheckinComment() )
+                .withLastContributor( getLastContributor() )
+                .withCreator( getCreator() )
+                .withLastModified( getLastModified() )
+                .withDateCreated( getDateCreated() )
+                .withSubject( getSubject() )
+                .withType( getType() )
+                .withExternalRelation( getExternalRelation() )
+                .withExternalSource( getExternalSource() )
+                .withDescription( getDescription() )
                 .withTags( getTags() )
-                .withDiscussion(getDiscussion())
-                .withLockInfo(retrieveLockInfo(Paths.convert(path)))
-                .withVersion(getVersion())
+                .withDiscussion( getDiscussion() )
+                .withLockInfo( retrieveLockInfo( Paths.convert( path ) ) )
+                .withVersion( getVersion() )
                 .build();
     }
 
     private ArrayList<VersionRecord> getVersion() {
-        return new ArrayList<VersionRecord>(versionAttributeView.readAttributes().history().records().size()) {{
-            for (final VersionRecord record : versionAttributeView.readAttributes().history().records()) {
-                add(new PortableVersionRecord(record.id(), record.author(), record.email(), record.comment(), record.date(), record.uri()));
+        return new ArrayList<VersionRecord>( versionAttributeView.readAttributes().history().records().size() ) {{
+            for ( final VersionRecord record : versionAttributeView.readAttributes().history().records() ) {
+                add( new PortableVersionRecord( record.id(), record.author(), record.email(), record.comment(), record.date(), record.uri() ) );
             }
         }};
     }
@@ -103,44 +104,44 @@ public class MetadataCreator {
     }
 
     private String getDescription() {
-        return dublinCoreView.readAttributes().descriptions().size() > 0 ? dublinCoreView.readAttributes().descriptions().get(0) : null;
+        return dublinCoreView.readAttributes().descriptions().size() > 0 ? dublinCoreView.readAttributes().descriptions().get( 0 ) : null;
     }
 
     private String getExternalSource() {
-        return dublinCoreView.readAttributes().sources().size() > 0 ? dublinCoreView.readAttributes().sources().get(0) : null;
+        return dublinCoreView.readAttributes().sources().size() > 0 ? dublinCoreView.readAttributes().sources().get( 0 ) : null;
     }
 
     private String getExternalRelation() {
-        return dublinCoreView.readAttributes().relations().size() > 0 ? dublinCoreView.readAttributes().relations().get(0) : null;
+        return dublinCoreView.readAttributes().relations().size() > 0 ? dublinCoreView.readAttributes().relations().get( 0 ) : null;
     }
 
     private String getType() {
-        return dublinCoreView.readAttributes().types().size() > 0 ? dublinCoreView.readAttributes().types().get(0) : null;
+        return dublinCoreView.readAttributes().types().size() > 0 ? dublinCoreView.readAttributes().types().get( 0 ) : null;
     }
 
     private String getSubject() {
-        return dublinCoreView.readAttributes().subjects().size() > 0 ? dublinCoreView.readAttributes().subjects().get(0) : null;
+        return dublinCoreView.readAttributes().subjects().size() > 0 ? dublinCoreView.readAttributes().subjects().get( 0 ) : null;
     }
 
     private Date getDateCreated() {
-        return new Date(versionAttributeView.readAttributes().creationTime().toMillis());
+        return new Date( versionAttributeView.readAttributes().creationTime().toMillis() );
     }
 
     private Date getLastModified() {
-        return new Date(versionAttributeView.readAttributes().lastModifiedTime().toMillis());
+        return new Date( versionAttributeView.readAttributes().lastModifiedTime().toMillis() );
     }
 
     private String getCreator() {
-        if (versionAttributeView.readAttributes().history().records().size() > 0) {
-            return versionAttributeView.readAttributes().history().records().get(0).author();
+        if ( versionAttributeView.readAttributes().history().records().size() > 0 ) {
+            return versionAttributeView.readAttributes().history().records().get( 0 ).author();
         } else {
             return null;
         }
     }
 
     private String getLastContributor() {
-        if (versionAttributeView.readAttributes().history().records().size() > 0) {
-            return versionAttributeView.readAttributes().history().records().get(versionAttributeView.readAttributes().history().records().size() - 1).author();
+        if ( versionAttributeView.readAttributes().history().records().size() > 0 ) {
+            return versionAttributeView.readAttributes().history().records().get( versionAttributeView.readAttributes().history().records().size() - 1 ).author();
         } else {
             return null;
         }
@@ -150,25 +151,27 @@ public class MetadataCreator {
         VersionAttributes versionAttributes = versionAttributeView.readAttributes();
         VersionHistory history = versionAttributes.history();
         List<VersionRecord> records = history.records();
-        if (records.size() > 0) {
-            return versionAttributeView.readAttributes().history().records().get(versionAttributeView.readAttributes().history().records().size() - 1).comment();
+        if ( records.size() > 0 ) {
+            return versionAttributeView.readAttributes().history().records().get( versionAttributeView.readAttributes().history().records().size() - 1 ).comment();
         } else {
             return null;
         }
     }
 
-    private LockInfo retrieveLockInfo(org.uberfire.backend.vfs.Path path) {
-        final org.uberfire.java.nio.file.Path lockPath = Paths.convert(PathFactory.newLock(path));
-        if (!configIOService.exists(lockPath)) {
-            return new LockInfo(false,
-                                "",
-                                path);
-        }
+    private LockInfo retrieveLockInfo( org.uberfire.backend.vfs.Path path ) {
+        final org.uberfire.java.nio.file.Path lockPath = Paths.convert( PathFactory.newLock( path ) );
+        try {
+            //See https://issues.jboss.org/browse/GUVNOR-2399. We simply try to read the lock file returning a default.
+            final String lockedBy = configIOService.readAllString( lockPath );
+            return new LockInfo( true,
+                                 lockedBy,
+                                 path );
 
-        final String lockedBy = configIOService.readAllString(lockPath);
-        return new LockInfo(true,
-                            lockedBy,
-                            path);
+        } catch ( NoSuchFileException nsfe ) {
+            return new LockInfo( false,
+                                 "",
+                                 path );
+        }
     }
 
 }

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataCreatorTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataCreatorTest.java
@@ -16,11 +16,12 @@
 
 package org.guvnor.common.services.backend.metadata;
 
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
@@ -29,89 +30,233 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.uberfire.io.IOService;
 import org.uberfire.io.attribute.DublinCoreView;
 import org.uberfire.java.nio.base.version.VersionAttributeView;
 import org.uberfire.java.nio.base.version.VersionAttributes;
 import org.uberfire.java.nio.base.version.VersionRecord;
+import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.api.FileSystemProviders;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 import org.uberfire.rpc.SessionInfo;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetadataCreatorTest {
 
     private SimpleFileSystemProvider fileSystemProvider;
 
-    @Mock private IOService configIOService;
-    @Mock private SessionInfo sessionInfo;
-    @Mock private DublinCoreView       dcoreView;
-    @Mock private DiscussionView       discussView;
-    @Mock private OtherMetaView        otherMetaView;
-    @Mock private VersionAttributeView versionAttributeView;
+    @Mock
+    private IOService configIOService;
+    @Mock
+    private SessionInfo sessionInfo;
+    @Mock
+    private DublinCoreView dcoreView;
+    @Mock
+    private DiscussionView discussView;
+    @Mock
+    private OtherMetaView otherMetaView;
+    @Mock
+    private VersionAttributeView versionAttributeView;
 
-    private MetadataCreator          service;
-    private Path                     mainFilePath;
+    private MetadataCreator service;
+    private Path mainFilePath;
     private ArrayList<VersionRecord> versionRecords;
 
     @Before
     public void setUp() throws Exception {
 
         versionRecords = new ArrayList<VersionRecord>();
-        VersionAttributes versionAttributes = new VersionAttributesMock(versionRecords);
-        when(versionAttributeView.readAttributes()).thenReturn(versionAttributes);
+        versionRecords.add( createVersionRecord() );
 
-        when(dcoreView.readAttributes()).thenReturn(new DublinCoreAttributesMock());
-        when(otherMetaView.readAttributes()).thenReturn(new OtherMetaAttributesMock());
-        when(discussView.readAttributes()).thenReturn(new DiscussionAttributesMock());
+        VersionAttributes versionAttributes = new VersionAttributesMock( versionRecords );
+        when( versionAttributeView.readAttributes() ).thenReturn( versionAttributes );
+
+        when( dcoreView.readAttributes() ).thenReturn( new DublinCoreAttributesMock() );
+        when( otherMetaView.readAttributes() ).thenReturn( new OtherMetaAttributesMock() );
+        when( discussView.readAttributes() ).thenReturn( new DiscussionAttributesMock() );
 
         fileSystemProvider = new SimpleFileSystemProvider();
 
         //Ensure URLs use the default:// scheme
         fileSystemProvider.forceAsDefault();
 
-        mainFilePath = fileSystemProvider.getPath(this.getClass().getResource("myfile.file").toURI());
+        mainFilePath = fileSystemProvider.getPath( this.getClass().getResource( "myfile.file" ).toURI() );
 
-        service = new MetadataCreator(mainFilePath, configIOService, sessionInfo, dcoreView, discussView, otherMetaView, versionAttributeView);
+        service = new MetadataCreator( mainFilePath,
+                                       configIOService,
+                                       sessionInfo,
+                                       dcoreView,
+                                       discussView,
+                                       otherMetaView,
+                                       versionAttributeView );
     }
 
     @Test
     public void testSimple() throws Exception {
-
-        versionRecords.add(createVersionRecord());
-
         Metadata metadata = service.create();
 
-        assertNotNull(metadata);
-        assertNotNull(metadata.getTags());
-        assertNotNull(metadata.getDiscussion());
-        assertNotNull(metadata.getVersion());
+        assertNotNull( metadata );
+        assertNotNull( metadata.getTags() );
+        assertNotNull( metadata.getDiscussion() );
+        assertNotNull( metadata.getVersion() );
+    }
+
+    @Test
+    //See https://issues.jboss.org/browse/GUVNOR-2399
+    public void testConcurrency() throws Throwable {
+        //Ensure FileSystemProviders has been setup
+        FileSystemProviders.getDefaultProvider();
+
+        //Mock FileSystem operations
+        final AtomicBoolean exists = new AtomicBoolean( false );
+        when( configIOService.exists( any( Path.class ) ) ).<Boolean>thenAnswer( new Answer<Boolean>() {
+            @Override
+            public Boolean answer( InvocationOnMock invocation ) throws Throwable {
+                return exists.get();
+            }
+        } );
+        when( configIOService.write( any( Path.class ),
+                                     any( String.class ) ) ).<Path>thenAnswer( new Answer<Path>() {
+            @Override
+            public Path answer( final InvocationOnMock invocation ) throws Throwable {
+                exists.set( true );
+                return mainFilePath;
+            }
+        } );
+        when( configIOService.readAllString( any( Path.class ) ) ).<String>thenAnswer( new Answer<String>() {
+            @Override
+            public String answer( InvocationOnMock invocation ) throws Throwable {
+                if ( !exists.get() ) {
+                    throw new NoSuchFileException();
+                }
+                return "content";
+            }
+        } );
+        doAnswer( new Answer<Void>() {
+            @Override
+            public Void answer( InvocationOnMock invocation ) throws Throwable {
+                exists.set( false );
+                return null;
+            }
+        } ).when( configIOService ).delete( any( Path.class ) );
+
+        final int THREADS = 100;
+        final Result result = new Result();
+        final ExecutorService es = Executors.newCachedThreadPool();
+        for ( int i = 0; i < THREADS; i++ ) {
+            final int threadCount = i;
+            final Operation op = i % 2 == 1 ? Operation.WRITE : Operation.CHECK;
+            es.execute( new Runnable() {
+                @Override
+                public void run() {
+                    try {
+
+                        System.out.println( "[Thread : " + threadCount + "] Running..." );
+                        switch ( op ) {
+                            case WRITE:
+                                System.out.println( "[Thread : " + threadCount + "] Writing..." + output() );
+                                configIOService.write( mainFilePath,
+                                                       "content" );
+                                configIOService.delete( mainFilePath );
+                                break;
+                            case CHECK:
+                                System.out.println( "[Thread : " + threadCount + "] Checking..." + output() );
+                                service.create();
+                        }
+
+                    } catch ( Throwable e ) {
+                        result.setFailed( true );
+                        result.setException( e );
+                    } finally {
+                        System.out.println( "[Thread : " + threadCount + "] Completed." );
+                    }
+                }
+
+                private String output() {
+                    if ( exists.get() ) {
+                        return "Exists";
+                    } else {
+                        return "Not exists";
+                    }
+                }
+            } );
+        }
+
+        try {
+            es.shutdown();
+            es.awaitTermination( 1000 * 5,
+                                 TimeUnit.MILLISECONDS );
+        } catch ( InterruptedException e ) {
+        }
+        if ( result.isFailed() ) {
+            throw result.getException();
+        }
+    }
+
+    private enum Operation {
+        WRITE,
+        CHECK
+    }
+
+    private static class Result {
+
+        private Throwable exception;
+        private boolean failed = false;
+
+        public Throwable getException() {
+            return exception;
+        }
+
+        public void setException( Throwable exception ) {
+            this.exception = exception;
+        }
+
+        public boolean isFailed() {
+            return failed;
+        }
+
+        public void setFailed( boolean failed ) {
+            this.failed = failed;
+        }
     }
 
     private VersionRecord createVersionRecord() {
         return new VersionRecord() {
-            @Override public String id() {
+            @Override
+            public String id() {
                 return "1";
             }
 
-            @Override public String author() {
+            @Override
+            public String author() {
                 return "admin";
             }
 
-            @Override public String email() {
+            @Override
+            public String email() {
                 return "admin@mail.zap";
             }
 
-            @Override public String comment() {
+            @Override
+            public String comment() {
                 return "Some commit";
             }
 
-            @Override public Date date() {
+            @Override
+            public Date date() {
                 return new Date();
             }
 
-            @Override public String uri() {
+            @Override
+            public String uri() {
                 return "myfile.file";
             }
         };


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2399

There was a race condition between checking if the lock file existed and reading it. This has been simplified to just attempt to read it and return the default ```LockInfo``` if the read fails (e.g. it did not exist). The test failed sporadically without the change; but never (at least in my attempts) failed with the change.