### PR TITLE
Bug 1316224 - User can not create projects in any other repository than master

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
@@ -41,8 +41,8 @@ import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.guvnor.m2repo.backend.server.GuvnorM2Repository;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
-import org.guvnor.structure.repositories.RepositoryService;
 import org.guvnor.structure.repositories.RepositoryEnvironmentUpdatedEvent;
+import org.guvnor.structure.repositories.RepositoryService;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,10 +128,10 @@ public class RepositoryStructureServiceImpl
     @Override
     public Path initRepositoryStructure( final POM pom,
                                          final String baseUrl,
-                                         final Repository repo,
+                                         final Repository repository,
                                          final boolean multiProject,
                                          final DeploymentMode mode ) {
-        if ( pom == null || baseUrl == null || repo == null ) {
+        if ( pom == null || baseUrl == null || repository == null ) {
             return null;
         }
 
@@ -144,7 +144,7 @@ public class RepositoryStructureServiceImpl
             pom.setPackaging( "pom" );
 
             //Creating the parent pom
-            final Path fsRoot = repo.getRoot();
+            final Path fsRoot = repository.getRoot();
             final Path pathToPom = pomService.create( fsRoot,
                                                       "",
                                                       pom );
@@ -152,13 +152,13 @@ public class RepositoryStructureServiceImpl
             // it needs to be deployed before the first child is created
             m2service.deployParentPom( pom.getGav() );
 
-            updateManagedStatus( repo,
+            updateManagedStatus( repository,
                                  true );
 
             return pathToPom;
 
         } else {
-            Project project = projectService.newProject( repo,
+            Project project = projectService.newProject( repository.getBranchRoot( repository.getDefaultBranch() ),
                                                          pom,
                                                          baseUrl,
                                                          mode );

--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/test/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImplTest.java
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-backend/src/test/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImplTest.java
@@ -244,14 +244,15 @@ public class RepositoryStructureServiceImplTest {
         final Repository repository = mock( Repository.class );
         final Path repositoryRootPath = mock( Path.class );
         when( repository.getAlias() ).thenReturn( "alias" );
-        when( repository.getRoot() ).thenReturn( repositoryRootPath );
+        when(repository.getDefaultBranch()).thenReturn( "master" );
+        when( repository.getBranchRoot( "master" ) ).thenReturn( repositoryRootPath );
 
         final Project project = mock( Project.class );
         final Path pomPath = mock( Path.class );
         when( project.getPomXMLPath() ).thenReturn( pomPath );
 
         when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ) ) ).thenReturn( Collections.<MavenRepositoryMetadata>emptySet() );
-        when( projectService.newProject( eq( repository ),
+        when( projectService.newProject( eq( repositoryRootPath ),
                                          eq( pom ),
                                          eq( "baseUrl" ),
                                          eq( DeploymentMode.VALIDATED ) ) ).thenReturn( project );
@@ -266,7 +267,7 @@ public class RepositoryStructureServiceImplTest {
                 times( 1 ) ).getRepositoriesResolvingArtifact( eq( gav ) );
 
         verify( projectService,
-                times( 1 ) ).newProject( eq( repository ),
+                times( 1 ) ).newProject( eq( repositoryRootPath ),
                                          eq( pom ),
                                          eq( "baseUrl" ),
                                          eq( DeploymentMode.VALIDATED ) );
@@ -301,7 +302,7 @@ public class RepositoryStructureServiceImplTest {
                                                                                                                    "local-url",
                                                                                                                    MavenRepositorySource.LOCAL ) );
                                                                              }} );
-        doThrow( gae ).when( projectService ).newProject( eq( repository ),
+        doThrow( gae ).when( projectService ).newProject( eq( repositoryRootPath ),
                                                           eq( pom ),
                                                           eq( "baseUrl" ),
                                                           eq( DeploymentMode.VALIDATED ) );
@@ -321,7 +322,7 @@ public class RepositoryStructureServiceImplTest {
                 times( 1 ) ).getRepositoriesResolvingArtifact( eq( gav ) );
 
         verify( projectService,
-                never() ).newProject( eq( repository ),
+                never() ).newProject( eq( repositoryRootPath ),
                                       eq( pom ),
                                       eq( "baseUrl" ),
                                       any( DeploymentMode.class ) );
@@ -336,7 +337,8 @@ public class RepositoryStructureServiceImplTest {
         final Repository repository = mock( Repository.class );
         final Path repositoryRootPath = mock( Path.class );
         when( repository.getAlias() ).thenReturn( "alias" );
-        when( repository.getRoot() ).thenReturn( repositoryRootPath );
+        when(repository.getDefaultBranch()).thenReturn( "master" );
+        when( repository.getBranchRoot( "master" ) ).thenReturn( repositoryRootPath );
 
         final Project project = mock( Project.class );
         final Path pomPath = mock( Path.class );
@@ -356,11 +358,11 @@ public class RepositoryStructureServiceImplTest {
                                                                                                                    "local-url",
                                                                                                                    MavenRepositorySource.LOCAL ) );
                                                                              }} );
-        doThrow( gae ).when( projectService ).newProject( eq( repository ),
+        doThrow( gae ).when( projectService ).newProject( eq( repositoryRootPath ),
                                                           eq( pom ),
                                                           eq( "baseUrl" ),
                                                           eq( DeploymentMode.VALIDATED ) );
-        when( projectService.newProject( eq( repository ),
+        when( projectService.newProject( eq( repositoryRootPath ),
                                          eq( pom ),
                                          eq( "baseUrl" ),
                                          eq( DeploymentMode.FORCED ) ) ).thenReturn( project );
@@ -380,7 +382,7 @@ public class RepositoryStructureServiceImplTest {
                 never() ).getRepositoriesResolvingArtifact( eq( gav ) );
 
         verify( projectService,
-                times( 1 ) ).newProject( eq( repository ),
+                times( 1 ) ).newProject( eq( repositoryRootPath ),
                                          eq( pom ),
                                          eq( "baseUrl" ),
                                          eq( DeploymentMode.FORCED ) );

--- a/guvnor-project/guvnor-project-api/pom.xml
+++ b/guvnor-project/guvnor-project-api/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>drools-workbench-models-datamodel-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/context/ProjectContext.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/context/ProjectContext.java
@@ -28,6 +28,7 @@ import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.UpdatedOrganizationalUnitEvent;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryRemovedEvent;
+import org.uberfire.backend.vfs.Path;
 
 /**
  * A specialized implementation that also has Project and Package scope
@@ -73,6 +74,10 @@ public class ProjectContext {
         for (ProjectContextChangeHandler handler : changeHandlers.values()) {
             handler.onChange();
         }
+    }
+
+    public Path getActiveRepositoryRoot(){
+        return getActiveRepository().getBranchRoot( getActiveBranch() );
     }
 
     public void setActiveOrganizationalUnit(final OrganizationalUnit activeOrganizationalUnit) {

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectServiceCore.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectServiceCore.java
@@ -39,24 +39,24 @@ public interface ProjectServiceCore<T> {
 
     /**
      * Creates a new project to the given path.
-     * @param repository
+     * @param repositoryRoot
      * @param pom
      * @param baseURL the base URL where the Guvnor is hosted in web container
      * @return
      */
-    T newProject( final Repository repository,
+    T newProject( final Path repositoryRoot,
                   final POM pom,
                   final String baseURL );
 
     /**
      * Creates a new project to the given path.
-     * @param repository
+     * @param repositoryRoot
      * @param pom
      * @param baseURL the base URL where the Guvnor is hosted in web container
      * @param mode Should creation check for the existence of other Artifacts with the same GAV
      * @return
      */
-    T newProject( final Repository repository,
+    T newProject( final Path repositoryRoot,
                   final POM pom,
                   final String baseURL,
                   final DeploymentMode mode );

--- a/guvnor-rest/guvnor-rest-backend/pom.xml
+++ b/guvnor-rest/guvnor-rest-backend/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>reflections</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
+++ b/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
@@ -58,7 +58,6 @@ import org.uberfire.io.IOService;
 @ApplicationScoped
 public class JobRequestHelper {
 
-    // TODO: add more logging in this class? (not at the beginning of methods, but during.. )
     private static final Logger logger = LoggerFactory.getLogger( JobRequestHelper.class );
 
     public static final String GUVNOR_BASE_URL = "/";
@@ -185,7 +184,7 @@ public class JobRequestHelper {
     }
 
     public JobResult createProject( final String jobId,
-                                    final String repositoryName,
+                                    final String repositoryAlias,
                                     final String projectName,
                                     String projectGroupId,
                                     String projectVersion,
@@ -193,7 +192,7 @@ public class JobRequestHelper {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( projectGroupId == null || projectGroupId.trim().isEmpty() ) {
             projectGroupId = projectName;
@@ -204,7 +203,7 @@ public class JobRequestHelper {
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             POM pom = new POM();
@@ -215,7 +214,7 @@ public class JobRequestHelper {
             pom.setName( projectName );
 
             try {
-                projectService.newProject( makeRepository( Paths.convert( repositoryPath ) ),
+                projectService.newProject( Paths.convert( repositoryPath ),
                                            pom,
                                            GUVNOR_BASE_URL );
 
@@ -229,8 +228,6 @@ public class JobRequestHelper {
                 result.setResult( "Project [" + projectName + "] already exists" );
                 return result;
             }
-
-            //TODO: handle errors, exceptions.
 
             result.setStatus( JobStatus.SUCCESS );
             return result;
@@ -247,26 +244,17 @@ public class JobRequestHelper {
         return sb.toString();
     }
 
-    private org.guvnor.structure.repositories.Repository makeRepository( final Path repositoryRoot ) {
-        return new GitRepository() {
-            @Override
-            public Path getRoot() {
-                return repositoryRoot;
-            }
-        };
-    }
-
     public JobResult deleteProject( String jobId,
-                                    String repositoryName,
+                                    String repositoryAlias,
                                     String projectName ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             String repoPathStr = repositoryPath.toUri().toString();
@@ -292,16 +280,16 @@ public class JobRequestHelper {
     }
 
     public JobResult compileProject( final String jobId,
-                                     final String repositoryName,
+                                     final String repositoryAlias,
                                      final String projectName ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             Project project = projectService.resolveProject( Paths.convert( repositoryPath.resolve( projectName ) ) );
@@ -332,16 +320,16 @@ public class JobRequestHelper {
     }
 
     public JobResult installProject( final String jobId,
-                                     final String repositoryName,
+                                     final String repositoryAlias,
                                      final String projectName ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             Project project = projectService.resolveProject( Paths.convert( repositoryPath.resolve( projectName ) ) );
@@ -385,17 +373,17 @@ public class JobRequestHelper {
     }
 
     public JobResult testProject( final String jobId,
-                                  final String repositoryName,
+                                  final String repositoryAlias,
                                   final String projectName,
                                   final BuildConfig config ) {
         final JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             Project project = projectService.resolveProject( Paths.convert( repositoryPath.resolve( projectName ) ) );
@@ -433,16 +421,16 @@ public class JobRequestHelper {
     }
 
     public JobResult deployProject( final String jobId,
-                                    final String repositoryName,
+                                    final String repositoryAlias,
                                     final String projectName ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         } else {
             Project project = projectService.resolveProject( Paths.convert( repositoryPath.resolve( projectName ) ) );
@@ -532,15 +520,15 @@ public class JobRequestHelper {
 
         List<org.guvnor.structure.repositories.Repository> repositories = new ArrayList<org.guvnor.structure.repositories.Repository>();
         if ( repositoryNameList != null && repositoryNameList.size() > 0 ) {
-            for ( String repoName : repositoryNameList ) {
-                org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repoName );
+            for ( String repositoryAlias : repositoryNameList ) {
+                org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
 
                 if ( repositoryPath == null ) {
                     result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-                    result.setResult( "Repository [" + repoName + "] does not exist" );
+                    result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
                     return result;
                 }
-                GitRepository repo = new GitRepository( repoName );
+                GitRepository repo = new GitRepository( repositoryAlias );
                 repositories.add( repo );
             }
             organizationalUnit = organizationalUnitService.createOrganizationalUnit( organizationalUnitName,
@@ -605,20 +593,20 @@ public class JobRequestHelper {
 
     public JobResult addRepositoryToOrganizationalUnit( final String jobId,
                                                         final String organizationalUnitName,
-                                                        final String repositoryName ) {
+                                                        final String repositoryAlias ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        if ( organizationalUnitName == null || repositoryName == null ) {
+        if ( organizationalUnitName == null || repositoryAlias == null ) {
             result.setStatus( JobStatus.BAD_REQUEST );
             result.setResult( "OrganizationalUnit name and Repository name must be provided" );
             return result;
         }
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         }
 
@@ -626,7 +614,7 @@ public class JobRequestHelper {
                                                                             null,
                                                                             null );
 
-        GitRepository repo = new GitRepository( repositoryName );
+        GitRepository repo = new GitRepository( repositoryAlias );
         try {
             organizationalUnitService.addRepository( organizationalUnit,
                                                      repo );
@@ -642,26 +630,26 @@ public class JobRequestHelper {
 
     public JobResult removeRepositoryFromOrganizationalUnit( final String jobId,
                                                              final String organizationalUnitName,
-                                                             final String repositoryName ) {
+                                                             final String repositoryAlias ) {
         JobResult result = new JobResult();
         result.setJobId( jobId );
 
-        if ( organizationalUnitName == null || repositoryName == null ) {
+        if ( organizationalUnitName == null || repositoryAlias == null ) {
             result.setStatus( JobStatus.BAD_REQUEST );
             result.setResult( "OrganizationalUnit name and Repository name must be provided" );
 
             return result;
         }
 
-        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryName );
+        org.uberfire.java.nio.file.Path repositoryPath = getRepositoryRootPath( repositoryAlias );
         if ( repositoryPath == null ) {
             result.setStatus( JobStatus.RESOURCE_NOT_EXIST );
-            result.setResult( "Repository [" + repositoryName + "] does not exist" );
+            result.setResult( "Repository [" + repositoryAlias + "] does not exist" );
             return result;
         }
 
         OrganizationalUnit organizationalUnit = new OrganizationalUnitImpl( organizationalUnitName, null, null );
-        GitRepository repo = new GitRepository( repositoryName );
+        GitRepository repo = new GitRepository( repositoryAlias );
         try {
             organizationalUnitService.removeRepository( organizationalUnit,
                                                         repo );
@@ -675,12 +663,12 @@ public class JobRequestHelper {
         return result;
     }
 
-    private org.uberfire.java.nio.file.Path getRepositoryRootPath( final String repositoryName ) {
-        org.guvnor.structure.repositories.Repository repo = repositoryService.getRepository( repositoryName );
-        if ( repo == null ) {
+    private org.uberfire.java.nio.file.Path getRepositoryRootPath( final String repositoryAlias ) {
+        org.guvnor.structure.repositories.Repository repository = repositoryService.getRepository( repositoryAlias );
+        if ( repository == null ) {
             return null;
         }
-        return Paths.convert( repo.getRoot() );
+        return Paths.convert( repository.getBranchRoot( repository.getDefaultBranch() ) );
     }
 
 }

--- a/guvnor-rest/guvnor-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateProjectTest.java
+++ b/guvnor-rest/guvnor-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateProjectTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.rest.backend;
+
+import java.net.URI;
+import java.util.HashSet;
+
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
+import org.guvnor.common.services.project.model.MavenRepositorySource;
+import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.GAVAlreadyExistsException;
+import org.guvnor.common.services.project.service.ProjectService;
+import org.guvnor.rest.client.JobResult;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.repositories.RepositoryService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.java.nio.file.FileAlreadyExistsException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class JobRequestHelperCreateProjectTest {
+
+    public SimpleFileSystemProvider fileSystemProvider;
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    @Mock
+    private ProjectService<? extends Project> projectService;
+
+    @InjectMocks
+    private JobRequestHelper jobRequestHelper = new JobRequestHelper();
+
+    @Before
+    public void setUp() throws Exception {
+        fileSystemProvider = new SimpleFileSystemProvider();
+
+        final Repository repository = mock( Repository.class );
+        when( repositoryService.getRepository( "myRepository" ) ).thenReturn( repository );
+        when( repository.getDefaultBranch() ).thenReturn( "master" );
+        final Path root = fileSystemProvider.getPath( URI.create( "default://master@myRepository/" ) );
+        when( repository.getBranchRoot( "master" ) ).thenReturn( Paths.convert( root ) );
+    }
+
+    @Test
+    public void testRepositoryDoesNotExist() throws Exception {
+        final JobResult jobResult = jobRequestHelper.createProject( "jobId",
+                                                                    "repositoryAlias",
+                                                                    "projectName",
+                                                                    "projectGroupId",
+                                                                    "projectVersion",
+                                                                    "projectDescription" );
+
+        assertEquals( "jobId", jobResult.getJobId() );
+        assertEquals( JobStatus.RESOURCE_NOT_EXIST, jobResult.getStatus() );
+        assertEquals( "Repository [repositoryAlias] does not exist", jobResult.getResult() );
+    }
+
+    @Test
+    public void testRepositoryDoesExist() throws Exception {
+        final JobResult jobResult = jobRequestHelper.createProject( "jobId",
+                                                                    "myRepository",
+                                                                    "projectName",
+                                                                    "projectGroupId",
+                                                                    "projectVersion",
+                                                                    "projectDescription" );
+
+        assertEquals( "jobId", jobResult.getJobId() );
+        assertEquals( JobStatus.SUCCESS, jobResult.getStatus() );
+        assertNull( jobResult.getResult() );
+    }
+
+    @Test
+    public void testNewProjectWhenGAVAlreadyExists() throws Exception {
+
+        final HashSet<MavenRepositoryMetadata> repositories = new HashSet<>();
+        repositories.add( new MavenRepositoryMetadata( "id",
+                                                       "url",
+                                                       MavenRepositorySource.LOCAL ) );
+
+        doThrow( new GAVAlreadyExistsException( new GAV( "projectGroupId:projectName:projectVersion" ),
+                                                repositories ) )
+                .when( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                                    any( POM.class ),
+                                                    eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+
+        final JobResult jobResult = jobRequestHelper.createProject( "jobId",
+                                                                    "myRepository",
+                                                                    "projectName",
+                                                                    "projectGroupId",
+                                                                    "projectVersion",
+                                                                    "projectDescription" );
+
+        assertEquals( "jobId", jobResult.getJobId() );
+        assertEquals( JobStatus.DUPLICATE_RESOURCE, jobResult.getStatus() );
+        assertEquals( "Project's GAV [projectGroupId:projectName:projectVersion] already exists at [id : url : LOCAL ]", jobResult.getResult() );
+    }
+
+    @Test
+    public void testNewProjectWhenFileAlreadyExists() throws Exception {
+
+        doThrow( new FileAlreadyExistsException( "myProject" ) )
+                .when( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                                    any( POM.class ),
+                                                    eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+
+        final JobResult jobResult = jobRequestHelper.createProject( "jobId",
+                                                                    "myRepository",
+                                                                    "myProject",
+                                                                    "projectGroupId",
+                                                                    "projectVersion",
+                                                                    "projectDescription" );
+
+        assertEquals( "jobId", jobResult.getJobId() );
+        assertEquals( JobStatus.DUPLICATE_RESOURCE, jobResult.getStatus() );
+        assertEquals( "Project [myProject] already exists", jobResult.getResult() );
+    }
+
+    @Test
+    public void testWeAreUsingCorrectGAV() throws Exception {
+
+
+        jobRequestHelper.createProject( "jobId",
+                                        "myRepository",
+                                        "myProject",
+                                        "projectGroupId",
+                                        "projectVersion",
+                                        "projectDescription" );
+
+        ArgumentCaptor<POM> pomArgumentCaptor = ArgumentCaptor.forClass( POM.class );
+        verify( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                             pomArgumentCaptor.capture(),
+                                             eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+        final POM pom = pomArgumentCaptor.getValue();
+        assertEquals( "projectGroupId", pom.getGav().getGroupId() );
+        assertEquals( "myProject", pom.getGav().getArtifactId() );
+        assertEquals( "projectVersion", pom.getGav().getVersion() );
+        assertEquals( "myProject", pom.getName() );
+        assertEquals( "projectDescription", pom.getDescription() );
+    }
+
+    @Test
+    public void testProjectGroupNull() throws Exception {
+        jobRequestHelper.createProject( "jobId",
+                                        "myRepository",
+                                        "myProject",
+                                        null,
+                                        "projectVersion",
+                                        "projectDescription" );
+
+        ArgumentCaptor<POM> pomArgumentCaptor = ArgumentCaptor.forClass( POM.class );
+        verify( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                             pomArgumentCaptor.capture(),
+                                             eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+        final POM pom = pomArgumentCaptor.getValue();
+        assertEquals( "myProject", pom.getGav().getGroupId() );
+    }
+
+    @Test
+    public void testProjectGroupEmpty() throws Exception {
+        jobRequestHelper.createProject( "jobId",
+                                        "myRepository",
+                                        "myProject",
+                                        "             ",
+                                        "projectVersion",
+                                        "projectDescription" );
+
+        ArgumentCaptor<POM> pomArgumentCaptor = ArgumentCaptor.forClass( POM.class );
+        verify( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                             pomArgumentCaptor.capture(),
+                                             eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+        final POM pom = pomArgumentCaptor.getValue();
+        assertEquals( "myProject", pom.getGav().getGroupId() );
+    }
+
+    @Test
+    public void testProjectVersionNull() throws Exception {
+
+
+        jobRequestHelper.createProject( "jobId",
+                                        "myRepository",
+                                        "myProject",
+                                        "projectGroupId",
+                                        null,
+                                        "projectDescription" );
+
+        ArgumentCaptor<POM> pomArgumentCaptor = ArgumentCaptor.forClass( POM.class );
+        verify( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                             pomArgumentCaptor.capture(),
+                                             eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+        final POM pom = pomArgumentCaptor.getValue();
+        assertEquals( "1.0", pom.getGav().getVersion() );
+    }
+
+    @Test
+    public void testProjectVersionEmpty() throws Exception {
+
+
+        jobRequestHelper.createProject( "jobId",
+                                        "myRepository",
+                                        "myProject",
+                                        "projectGroupId",
+                                        "               ",
+                                        "projectDescription" );
+
+        ArgumentCaptor<POM> pomArgumentCaptor = ArgumentCaptor.forClass( POM.class );
+        verify( projectService ).newProject( any( org.uberfire.backend.vfs.Path.class ),
+                                             pomArgumentCaptor.capture(),
+                                             eq( JobRequestHelper.GUVNOR_BASE_URL ) );
+
+        final POM pom = pomArgumentCaptor.getValue();
+        assertEquals( "1.0", pom.getGav().getVersion() );
+    }
+
+}

--- a/guvnor-rest/guvnor-rest-backend/src/test/resources/META-INF/beans.xml
+++ b/guvnor-rest/guvnor-rest-backend/src/test/resources/META-INF/beans.xml
@@ -1,7 +1,5 @@
 <beans>
   <alternatives>
-    <class>org.kie.workbench.common.services.rest.TestAppSetup</class>
     <class>org.guvnor.test.GuvnorTestAppSetup</class>
-    <class>org.kie.workbench.common.services.rest.TestIdentityFactory</class>
    </alternatives>
 </beans>

--- a/guvnor-webapp/src/main/java/org/guvnor/server/MavenProjectServiceImpl.java
+++ b/guvnor-webapp/src/main/java/org/guvnor/server/MavenProjectServiceImpl.java
@@ -91,13 +91,12 @@ public class MavenProjectServiceImpl
     }
 
     @Override
-    public Project newProject( final org.guvnor.structure.repositories.Repository repository,
+    public Project newProject( final Path fsRoot,
                                final POM pom,
                                final String baseUrl ) {
-        final FileSystem fs = Paths.convert( repository.getRoot() ).getFileSystem();
+        final FileSystem fs = Paths.convert( fsRoot ).getFileSystem();
         try {
             //Projects are always created in the FS root
-            final Path fsRoot = repository.getRoot();
             final Path projectRootPath = Paths.convert( Paths.convert( fsRoot ).resolve( pom.getName() ) );
 
             ioService.startBatch( new FileSystem[]{ fs },
@@ -142,11 +141,11 @@ public class MavenProjectServiceImpl
     }
 
     @Override
-    public Project newProject( final Repository repository,
+    public Project newProject( final Path repositoryRoot,
                                final POM pom,
                                final String baseURL,
                                final DeploymentMode mode ) {
-        return newProject( repository,
+        return newProject( repositoryRoot,
                            pom,
                            baseURL );
     }


### PR DESCRIPTION
The new project is now created with the Path to the branch, not using the Repository object. Repository is just a set of branches, it has no knowledge about what branch the user is in.

Tried to add tests for the parts I touched. Unless the change was just variable/method name, but let me know if you want more.

https://github.com/droolsjbpm/guvnor/pull/285
https://github.com/droolsjbpm/kie-wb-common/pull/302
https://github.com/droolsjbpm/drools-wb/pull/143
https://github.com/droolsjbpm/jbpm-console-ng/pull/364
https://github.com/droolsjbpm/optaplanner-wb/pull/46
https://github.com/droolsjbpm/kie-wb-distributions/pull/228