### PR TITLE
GUVNOR-2352 : Adding of manual dependency does not work correctly

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependencies.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependencies.java
@@ -47,6 +47,16 @@ public class Dependencies
         return false;
     }
 
+    public Dependency get( final GAV gav ) {
+        for ( Dependency dependency : dependencies ) {
+            if ( dependency.isGAVEqual( gav ) ) {
+                return dependency;
+            }
+        }
+
+        return null;
+    }
+
     public Collection<GAV> getGavs( final String... scopes ) {
         final List<String> scopesAsList = Arrays.asList( scopes );
 

--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependency.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependency.java
@@ -16,9 +16,6 @@
 
 package org.guvnor.common.services.project.model;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.jboss.errai.common.client.api.annotations.Portable;
 
 @Portable
@@ -26,8 +23,6 @@ public class Dependency
         extends GAV {
 
     private String scope;
-
-    private Set<String> packages = new HashSet<String>();
 
     public Dependency() {
     }
@@ -44,11 +39,4 @@ public class Dependency
         this.scope = scope;
     }
 
-    public Set<String> getPackages() {
-        return packages;
-    }
-
-    public void addPackages( final Set<String> packages ) {
-        this.packages.addAll( packages );
-    }
 }

--- a/guvnor-project/guvnor-project-api/src/test/java/org/guvnor/common/services/project/model/DependenciesTest.java
+++ b/guvnor-project/guvnor-project-api/src/test/java/org/guvnor/common/services/project/model/DependenciesTest.java
@@ -26,16 +26,18 @@ public class DependenciesTest {
 
 
     private Dependencies dependencies;
+    private Dependency droolsCore;
+    private Dependency junit;
 
     @Before
     public void setUp() throws Exception {
         dependencies = new Dependencies();
 
-        final Dependency droolsCore = new Dependency( new GAV( "org.drools:drools-core:5.0" ) );
+        droolsCore = new Dependency( new GAV( "org.drools:drools-core:5.0" ) );
         droolsCore.setScope( "compile" );
         dependencies.add( droolsCore );
 
-        final Dependency junit = new Dependency( new GAV( "junit:junit:4.11" ) );
+        junit = new Dependency( new GAV( "junit:junit:4.11" ) );
         junit.setScope( "test" );
         dependencies.add( junit );
     }
@@ -46,6 +48,16 @@ public class DependenciesTest {
         assertEquals( 2, gavs.size() );
         assertContains( gavs, "org.drools", "drools-core", "5.0" );
         assertContains( gavs, "junit", "junit", "4.11" );
+    }
+
+    @Test
+    public void testFindByGav() throws Exception {
+        assertEquals( droolsCore, dependencies.get( new GAV( "org.drools:drools-core:5.0" ) ) );
+    }
+
+    @Test
+    public void testNullWhenNoResults() throws Exception {
+        assertNull( dependencies.get( new GAV( "org.drools:drools-core:112.0" ) ) );
     }
 
     public static void assertContains( final Collection<GAV> gavs,


### PR DESCRIPTION
Removed the packages from `Dependency`. They were lazy loaded by sending the instances to `DependencyService` for the names to be filled up. This can cause bugs and `Dependency` class is really our version of the Maven Dependency. The version Maven has does not have the info about packages either.

https://github.com/droolsjbpm/kie-wb-common/pull/321