### PR TITLE
DROOLS-1057: Change kie-ci API to make it able to deploy on any remote repository. Fixes to guvnor following change to kie-ci API

### DIFF
--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/RepositoryResolverTestUtils.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/RepositoryResolverTestUtils.java
@@ -90,9 +90,9 @@ public class RepositoryResolverTestUtils {
             //Nothing to override, just a sub-class to expose Constructor
         };
 
-        mavenRepository.deployArtifact( releaseId,
-                                        "content".getBytes(),
-                                        pomXml.getBytes() );
+        mavenRepository.installArtifact( releaseId,
+                                         "content".getBytes(),
+                                         pomXml.getBytes() );
     }
 
     /**


### PR DESCRIPTION
See https://github.com/droolsjbpm/drools/commit/2f9b2c740c7601fa7f811d6ac2d5d48fcbb97583

This changed the API for MavenRepository. This PR simply changes guvnor to use the revised API.