### PR TITLE
guvnor-inbox-backend: add test-scoped servlet-api to fix faling test

### DIFF
--- a/guvnor-inbox/guvnor-inbox-backend/pom.xml
+++ b/guvnor-inbox/guvnor-inbox-backend/pom.xml
@@ -118,6 +118,11 @@
       <artifactId>guvnor-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
This fixes the currently failing test `InboxEntrySecurity_InboxEntrySecurityTestTest` (huh, that's a weird name :))