### PR TITLE
[6.4.x] RHBPMS-3997: [GSS](6.3.x) Project dependencies are not retained in BPM Suite 6.3.0

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependencies.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/model/Dependencies.java
@@ -75,6 +75,10 @@ public class Dependencies
         }
     }
 
+    public Collection<GAV> getCompileScopedGavs() {
+        return getGavs( "compile", null );
+    }
+
     @Override public int size() {
         return dependencies.size();
     }

--- a/guvnor-project/guvnor-project-api/src/test/java/org/guvnor/common/services/project/model/DependenciesTest.java
+++ b/guvnor-project/guvnor-project-api/src/test/java/org/guvnor/common/services/project/model/DependenciesTest.java
@@ -99,4 +99,12 @@ public class DependenciesTest {
         assertEquals( 1, gavs.size() );
         assertContains( gavs, "org.drools", "drools-core", "5.0" );
     }
+
+
+    @Test
+    public void testGetCompileScopedGavsMethod() throws Exception {
+        final Collection<GAV> gavs = dependencies.getCompileScopedGavs();
+        assertEquals( 1, gavs.size() );
+        assertContains( gavs, "org.drools", "drools-core", "5.0" );
+    }
 }


### PR DESCRIPTION
This PR adds a method that retrieves compile dependencies. As "compile" is the default scope, this PR makes dependencies without scope be handled as a compile dependency.
