### PR TITLE
[6.4.x] RHBRMS-2477: Allow users to edit project's GAV information in business central Project Editor when it has a parent

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectRepositoryResolver.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/service/ProjectRepositoryResolver.java
@@ -31,6 +31,8 @@ public interface ProjectRepositoryResolver {
 
     String CONFLICTING_GAV_CHECK_DISABLED = "org.guvnor.project.gav.check.disabled";
 
+    String CHILD_GAV_EDIT_ENABLED = "org.guvnor.project.gav.child.edit.enabled";
+
     /**
      * Get a collection of Repositories a Project will resolve artifacts against. The list will include
      * any Repositories defined in settings.xml

--- a/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/GAVPreferencesLoader.java
+++ b/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/GAVPreferencesLoader.java
@@ -29,16 +29,17 @@ import org.slf4j.LoggerFactory;
  * Make the "org.guvnor.project.gav.check.disabled" System Property available client-side.
  */
 @ApplicationScoped
-public class GAVCheckPreferencesLoader implements ApplicationPreferencesLoader {
+public class GAVPreferencesLoader implements ApplicationPreferencesLoader {
 
-    private static final Logger log = LoggerFactory.getLogger( GAVCheckPreferencesLoader.class );
+    private static final Logger log = LoggerFactory.getLogger( GAVPreferencesLoader.class );
 
     @Override
     public Map<String, String> load() {
         final Map<String, String> preferences = new HashMap<String, String>();
         addSystemProperty( preferences,
                            ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
-
+        addSystemProperty( preferences,
+                           ProjectRepositoryResolver.CHILD_GAV_EDIT_ENABLED );
         return preferences;
     }
 

--- a/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/GAVPreferencesLoaderTest.java
+++ b/guvnor-project/guvnor-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/GAVPreferencesLoaderTest.java
@@ -25,16 +25,16 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class GAVCheckPreferencesLoaderTest {
+public class GAVPreferencesLoaderTest {
 
     private String oldPropertyValue;
 
-    private GAVCheckPreferencesLoader loader;
+    private GAVPreferencesLoader loader;
 
     @Before
     public void setup() {
         oldPropertyValue = System.getProperty( ProjectRepositoryResolver.CONFLICTING_GAV_CHECK_DISABLED );
-        loader = new GAVCheckPreferencesLoader();
+        loader = new GAVPreferencesLoader();
     }
 
     @After

--- a/guvnor-project/guvnor-project-client/pom.xml
+++ b/guvnor-project/guvnor-project-client/pom.xml
@@ -85,6 +85,16 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
 
@@ -102,6 +112,12 @@
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+  
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanel.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/POMEditorPanel.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+import org.guvnor.common.services.project.client.util.ApplicationPreferences;
 import org.guvnor.common.services.project.model.POM;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
@@ -58,18 +59,21 @@ public class POMEditorPanel
 
         view.setName( model.getName() );
         view.setDescription( model.getDescription() );
+        view.enableGroupID();
+        view.enableArtifactID();
+        view.enableVersion();
+
         if ( model.hasParent() ) {
             view.setParentGAV( model.getParent() );
             view.showParentGAV();
-            view.disableGroupID( "" );
-            view.enableArtifactID();
-            view.disableVersion( "" );
+            if ( !ApplicationPreferences.isChildGAVEditEnabled() ) {
+                view.disableGroupID( "" );
+                view.disableVersion( "" );
+            }
         } else {
             view.hideParentGAV();
-            view.enableGroupID();
-            view.enableArtifactID();
-            view.enableVersion();
         }
+
         view.setGAV( model.getGav() );
         view.addArtifactIdChangeHandler( new ArtifactIdChangeHandler() {
             @Override

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/ProjectEntryPoint.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/ProjectEntryPoint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.client;
+
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.client.util.ApplicationPreferences;
+import org.guvnor.common.services.shared.config.AppConfigService;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.api.AfterInitialization;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+
+@EntryPoint
+public class ProjectEntryPoint {
+
+    private Caller<AppConfigService> appConfigService;
+
+    @Inject
+    public ProjectEntryPoint( final Caller<AppConfigService> appConfigService ) {
+        this.appConfigService = appConfigService;
+    }
+
+    @AfterInitialization
+    public void startApp() {
+        loadPreferences();
+    }
+
+    private void loadPreferences() {
+        appConfigService.call( new RemoteCallback<Map<String, String>>() {
+            @Override
+            public void callback( final Map<String, String> response ) {
+                ApplicationPreferences.setUp( response );
+            }
+        } ).loadPreferences();
+    }
+}

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/util/ApplicationPreferences.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/util/ApplicationPreferences.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.client.util;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+
+/**
+ * Storage for global preferences. Preferences effect behaviour and display.
+ */
+public class ApplicationPreferences {
+
+    private static ApplicationPreferences instance = new ApplicationPreferences( Collections.<String, String>emptyMap() );
+
+    private Map<String, String> preferences = Collections.<String, String>emptyMap();
+
+    private ApplicationPreferences( Map<String, String> preferences ) {
+        this.preferences = preferences;
+    }
+
+    public static void setUp( Map<String, String> map ) {
+        instance = new ApplicationPreferences( map );
+    }
+
+    public static boolean isChildGAVEditEnabled() {
+        return Boolean.parseBoolean( getPreference( ProjectRepositoryResolver.CHILD_GAV_EDIT_ENABLED ) );
+    }
+
+    private static String getPreference( final String key ) {
+        return instance.preferences.get( key );
+    }
+}

--- a/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/ProjectEntryPointTest.java
+++ b/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/ProjectEntryPointTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.client;
+
+import com.google.gwt.dev.util.collect.HashMap;
+import org.guvnor.common.services.project.client.util.ApplicationPreferences;
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+import org.guvnor.common.services.shared.config.AppConfigService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectEntryPointTest {
+
+    @Mock
+    private AppConfigService appConfigService;
+
+    private ProjectEntryPoint entryPoint;
+
+    @Before
+    public void setup() {
+        when( appConfigService.loadPreferences() ).thenReturn( preferences() );
+
+        entryPoint = spy( new ProjectEntryPoint( new CallerMock<AppConfigService>( appConfigService ) ) );
+    }
+
+    @Test
+    public void startAppTest() {
+        entryPoint.startApp();
+
+        assertTrue( ApplicationPreferences.isChildGAVEditEnabled() );
+    }
+
+    private HashMap<String, String> preferences() {
+        return new HashMap<String, String>() {{
+            put( ProjectRepositoryResolver.CHILD_GAV_EDIT_ENABLED, "true" );
+        }};
+    }
+}

--- a/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/util/ApplicationPreferencesTest.java
+++ b/guvnor-project/guvnor-project-client/src/test/java/org/guvnor/common/services/project/client/util/ApplicationPreferencesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.client.util;
+
+import java.util.HashMap;
+
+import org.guvnor.common.services.project.service.ProjectRepositoryResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ApplicationPreferencesTest {
+
+    @Test
+    public void testIsChildGAVEditEnabledDefaultValue() {
+        setChildGAVEdit( "" );
+        assertFalse( ApplicationPreferences.isChildGAVEditEnabled() );
+    }
+
+    @Test
+    public void testIsChildGAVEditEnabledSetUp() {
+        setChildGAVEdit( "true" );
+        assertTrue( ApplicationPreferences.isChildGAVEditEnabled() );
+    }
+
+    private void setChildGAVEdit( final String value ) {
+        ApplicationPreferences.setUp( new HashMap<String, String>() {{
+            put( ProjectRepositoryResolver.CHILD_GAV_EDIT_ENABLED, value );
+        }} );
+    }
+}


### PR DESCRIPTION
This PR adds a new system property that allows users to edit GAV information when it has a parent GAV.