### PR TITLE
[RHBRMS-2447] add missing required metainfo into asset-mgmt-project POM

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/filtered-resources/kjar/pom.xml
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/filtered-resources/kjar/pom.xml
@@ -13,6 +13,30 @@
   <name>Guvnor - Asset Management Project</name>
   <description>Guvnor - Asset Management Project (includes processes to manage business assets)</description>
 
+  <url>http://www.kiegroup.org</url>
+  <organization>
+    <name>JBoss by Red Hat</name>
+    <url>http://www.jboss.org/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com/droolsjbpm/guvnor.git</connection>
+    <developerConnection>scm:git:git@github.com:droolsjbpm/guvnor.git</developerConnection>
+    <url>https://github.com/droolsjbpm/guvnor</url>
+  </scm>
+  <developers>
+    <developer>
+      <name>All developers are listed on the team website</name>
+      <url>http://www.drools.org/community/team.html</url>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
 * required by Nexus to pass release validation rules

@manstis could you please quickly check this? It should hopefully the last thing missing now.