### PR TITLE
[6.5.x] moved setAssetsManagementGrant check to showForm to make sure require…

### DIFF
--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
@@ -88,7 +88,6 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
     public void init() {
         view.init( this,
                    isOuMandatory() );
-        setAssetsManagementGrant();
     }
 
     @AfterInitialization
@@ -238,6 +237,7 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
 
     public void showForm() {
         view.reset();
+        setAssetsManagementGrant();
         view.show();
     }
 

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenterTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenterTest.java
@@ -392,6 +392,14 @@ public class CloneRepositoryPresenterTest {
     }
 
     @Test
+    public void testAssetsManagementGrantCalled() {
+        presenter.showForm();
+
+        verify( view,
+                times( 1 ) ).enableManagedRepoCreation(anyBoolean());
+    }
+
+    @Test
     public void testCloneManagedRepository() {
         when( view.isGitUrlEmpty() ).thenReturn( false );
         when( repositoryPreferences.isOUMandatory() ).thenReturn( false );


### PR DESCRIPTION
…d roles are loaded in KieACL

Recently it was few times reported that there is no option to mark repo as managed while cloning based on the investigation it turned out that the check was done to early - before the roles are loaded from workbench policy and thus resulting always as disabled.

Tests for clone repo are already there but not sure this position change should be tested or not...