### PR TITLE
[UF-403]: Fix added to solve origin null parameter problem

### DIFF
--- a/guvnor-structure/guvnor-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/GitMetadataStoreImpl.java
+++ b/guvnor-structure/guvnor-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/GitMetadataStoreImpl.java
@@ -60,12 +60,13 @@ public class GitMetadataStoreImpl implements GitMetadataStore {
     public void write( String name,
                        String origin ) {
 
-        GitMetadataImpl repositoryMetadata = (GitMetadataImpl) this.read( name ).orElse( new GitMetadataImpl( name, origin ) );
-        GitMetadataImpl newRepositoryMetadata = new GitMetadataImpl( name, origin, repositoryMetadata.getForks() );
-
+        GitMetadataImpl repositoryMetadata = (GitMetadataImpl) this.read( name ).orElse( new GitMetadataImpl( name ) );
         this.removeForkFromOrigin( repositoryMetadata );
+        GitMetadataImpl newRepositoryMetadata = new GitMetadataImpl( name, repositoryMetadata.getForks() );
 
         if ( isStorableOrigin( origin ) ) {
+            newRepositoryMetadata = new GitMetadataImpl( name, origin, repositoryMetadata.getForks() );
+
             GitMetadataImpl originMetadata = (GitMetadataImpl) this.read( origin ).orElse( new GitMetadataImpl( origin ) );
             List<String> forks = originMetadata.getForks();
             forks.add( name );
@@ -102,7 +103,7 @@ public class GitMetadataStoreImpl implements GitMetadataStore {
     private void removeOriginFromForks( final GitMetadata metadata ) {
         List<GitMetadata> forks = this.getForks( metadata );
         forks.forEach( fork -> {
-            GitMetadata newForkImpl = new GitMetadataImpl( fork.getName(), "", fork.getForks() );
+            GitMetadata newForkImpl = new GitMetadataImpl( fork.getName(), fork.getForks() );
             this.storage.write( buildPath( fork.getName() ), newForkImpl );
         } );
     }

--- a/guvnor-structure/guvnor-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/git/GitMetadataImplStoreTest.java
+++ b/guvnor-structure/guvnor-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/git/GitMetadataImplStoreTest.java
@@ -117,6 +117,14 @@ public class GitMetadataImplStoreTest {
     }
 
     @Test
+    public void testWriteWithNullOrigin() {
+
+        metadataStore.write( "test/repo", null );
+        assertEquals( "test/repo", metadatas.get( "/test/repo.metadata" ).getName() );
+
+    }
+
+    @Test
     public void testWriteTwoForks() {
 
         metadataStore.write( "test/repo", "origin/repo" );


### PR DESCRIPTION
@manstis this solves the problem for: _java.lang.IllegalArgumentException: Parameter named 'origin' should be not null!_

I've added a test also, to check that behavior.

