### PR TITLE
Maven binary, add GAV properties and absolute path

### DIFF
--- a/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/executor/MavenDependencyConfigExecutor.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/executor/MavenDependencyConfigExecutor.java
@@ -15,6 +15,7 @@
  */
 package org.guvnor.ala.build.maven.executor;
 
+import java.net.URI;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -55,8 +56,8 @@ public class MavenDependencyConfigExecutor implements FunctionConfigExecutor<Mav
         }
         final String absolutePath = artifact.getFile().getAbsolutePath();
         LOGGER.debug("Resolved Artifact path: {}", absolutePath);
-        final Path path = FileSystems.getFileSystem(artifact.getFile().toURI()).getPath(artifact.getFile().getAbsolutePath());
-        final MavenBinary binary = new MavenBinaryImpl(path, artifact.getArtifactId());
+        final Path path = FileSystems.getFileSystem(URI.create("file://default")).getPath(absolutePath);
+        final MavenBinary binary = new MavenBinaryImpl(path, artifact.getArtifactId(), artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
         buildRegistry.registerBinary(binary);
         return Optional.of(binary);
     }

--- a/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/MavenBinary.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/MavenBinary.java
@@ -19,7 +19,7 @@ package org.guvnor.ala.build.maven.model;
 import org.guvnor.ala.build.Binary;
 
 /*
- * This interface represent the basic inforamtion about a Binary produced by a Maven Build process
+ * This interface represent the basic information about a Binary produced by a Maven Build process
  * @see Binary
  */
 public interface MavenBinary extends Binary {
@@ -27,5 +27,11 @@ public interface MavenBinary extends Binary {
     default String getType() {
         return "Maven";
     }
+
+    String getArtifactId();
+
+    String getVersion();
+
+    String getGroupId();
 
 }

--- a/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/impl/MavenBinaryImpl.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/impl/MavenBinaryImpl.java
@@ -26,13 +26,22 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
 public class MavenBinaryImpl implements MavenBinary,
                                         CloneableConfig<MavenBinary> {
 
-    private Path path;
+    private final Path path;
 
-    private String name;
+    private final String name;
 
-    public MavenBinaryImpl(final Path path, final String name) {
-        this.path = checkNotNull( "path", path );
-        this.name = checkNotNull( "name", name );
+    private final String artifactId;
+
+    private final String version;
+
+    private final String groupId;
+
+    public MavenBinaryImpl(final Path path, final String name, final String groupId, final String artifactId, final String version) {
+        this.path = checkNotNull("path", path);
+        this.name = checkNotNull("name", name);
+        this.artifactId = checkNotNull("artifactId", artifactId);
+        this.version = checkNotNull("version", version);
+        this.groupId = checkNotNull("groupId", groupId);
     }
 
     @Override
@@ -51,7 +60,33 @@ public class MavenBinaryImpl implements MavenBinary,
     }
 
     @Override
-    public MavenBinary asNewClone( final MavenBinary source ) {
-        return new MavenBinaryImpl( source.getPath(), source.getName() );
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getGroupId() {
+        return groupId;
+    }
+
+    @Override
+    public MavenBinary asNewClone(final MavenBinary source) {
+        return new MavenBinaryImpl(source.getPath(), source.getName(), groupId, artifactId, version);
+    }
+
+    @Override
+    public String toString() {
+        return "MavenBinaryImpl{" +
+                "path=" + path +
+                ", name='" + name + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", version='" + version + '\'' +
+                ", groupId='" + groupId + '\'' +
+                '}';
     }
 }

--- a/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/impl/MavenProjectBinaryImpl.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/model/impl/MavenProjectBinaryImpl.java
@@ -21,15 +21,27 @@ import org.guvnor.ala.build.maven.model.MavenBinary;
 import org.guvnor.ala.config.CloneableConfig;
 import org.uberfire.java.nio.file.Path;
 
-import static org.uberfire.commons.validation.PortablePreconditions.*;
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 
 public class MavenProjectBinaryImpl implements MavenBinary,
                                         CloneableConfig<MavenBinary> {
 
+    private final Path path;
+
     private final Project sourceProject;
 
-    public MavenProjectBinaryImpl(final Project sourceProject ) {
-        this.sourceProject = checkNotNull( "sourceProject", sourceProject );
+    private final String artifactId;
+
+    private final String version;
+
+    private final String groupId;
+
+    public MavenProjectBinaryImpl(final Path path, final Project sourceProject, final String groupId, final String artifactId, final String version) {
+        this.path = checkNotNull("path", path);
+        this.sourceProject = checkNotNull("sourceProject", sourceProject);
+        this.artifactId = checkNotNull("artifactId", artifactId);
+        this.version = checkNotNull("version", version);
+        this.groupId = checkNotNull("groupId", groupId);
     }
 
     @Override
@@ -39,7 +51,7 @@ public class MavenProjectBinaryImpl implements MavenBinary,
 
     @Override
     public Path getPath() {
-        return sourceProject.getPath();
+        return path;
     }
 
     @Override
@@ -48,7 +60,33 @@ public class MavenProjectBinaryImpl implements MavenBinary,
     }
 
     @Override
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String getGroupId() {
+        return groupId;
+    }
+
+    @Override
     public MavenBinary asNewClone( final MavenBinary source ) {
-        return new MavenProjectBinaryImpl( source.getProject() );
+        return new MavenProjectBinaryImpl( path, source.getProject(), groupId, artifactId, version );
+    }
+
+    @Override
+    public String toString() {
+        return "MavenProjectBinaryImpl{" +
+                "path=" + path +
+                ", sourceProject=" + sourceProject +
+                ", artifactId='" + artifactId + '\'' +
+                ", version='" + version + '\'' +
+                ", groupId='" + groupId + '\'' +
+                '}';
     }
 }

--- a/guvnor-ala/guvnor-ala-build-maven/src/test/java/org/guvnor/ala/build/maven/executor/MavenDependencyConfigExecutorTest.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/test/java/org/guvnor/ala/build/maven/executor/MavenDependencyConfigExecutorTest.java
@@ -91,7 +91,7 @@ public class MavenDependencyConfigExecutorTest {
                 {
                     put("artifact", groupId + ":" + artifactId + ":pom:" + version);
                 }
-            }, pipe, (Binary b) -> System.out.println(b.getName()));
+            }, pipe, System.out::println);
 
             final List<Binary> allBinaries = buildRegistry.getAllBinaries();
             assertNotNull(allBinaries);
@@ -100,6 +100,10 @@ public class MavenDependencyConfigExecutorTest {
             final MavenBinary binary = (MavenBinary) allBinaries.get(0);
             assertEquals("Maven", binary.getType());
             assertEquals(artifactId, binary.getName());
+            assertEquals(groupId, binary.getGroupId());
+            assertEquals(artifactId, binary.getArtifactId());
+            assertEquals(version, binary.getVersion());
+            assertEquals(m2Folder + "/org/guvnor/ala/maven-ala-artifact-test/1/maven-ala-artifact-test-1.pom", binary.getPath().toString());
         } finally {
             if (oldSettingsXmlPath == null) {
                 System.clearProperty(CUSTOM_SETTINGS_PROPERTY);
@@ -130,29 +134,14 @@ public class MavenDependencyConfigExecutorTest {
     }
 
     private Path generateSettingsXml() throws IOException {
-        final String localRepositoryUrl = m2Folder.toURI().toURL().toExternalForm();
+        final String localRepositoryUrl = m2Folder.getAbsolutePath();
         String settingsXml =
                 "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"\n" +
                         "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
                         "      xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0\n" +
                         "                          http://maven.apache.org/xsd/settings-1.0.0.xsd\">\n" +
-                        "  <profiles>\n" +
-                        "    <profile>\n" +
-                        "      <id>repos</id>\n" +
-                        "      <activation>\n" +
-                        "        <activeByDefault>true</activeByDefault>\n" +
-                        "      </activation>\n" +
-                        "      <repositories>\n" +
-                        "        <repository>\n" +
-                        "          <id>myTestRepo</id>\n" +
-                        "          <name>My Test Repo</name>\n" +
-                        "          <url>" + localRepositoryUrl + "</url>\n" +
-                        "          <releases><enabled>true</enabled></releases>\n" +
-                        "          <snapshots><enabled>true</enabled></snapshots>\n" +
-                        "        </repository>\n" +
-                        "    </repositories>\n" +
-                        "    </profile>\n" +
-                        "  </profiles>\n" +
+                        "  <localRepository>" + localRepositoryUrl + "</localRepository>\n" +
+                        "  <offline>true</offline>\n" +
                         "</settings>\n";
 
         final Path settingsXmlPath = Files.createTempFile(m2Folder.toPath(), "settings", ".xml");

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/impl/ContextAwareWildflyRuntimeExecConfig.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/impl/ContextAwareWildflyRuntimeExecConfig.java
@@ -49,11 +49,10 @@ public class ContextAwareWildflyRuntimeExecConfig implements
     public void setContext( final Map<String, ?> context ) {
         this.context = context;
         MavenBinary binary = (MavenBinary) context.get( "binary" );
-        String binaryPath = binary.getProject().getExpectedBinary();
 
         WildflyProvider provider = (WildflyProvider) context.get( "wildfly-provider" );
         this.providerId = provider;
-        this.warPath = binary.getProject().getTempDir() + "/target/" + binaryPath;
+        this.warPath = binary.getPath().toString();
 
     }
 

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/WildflyRuntimeTest.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/WildflyRuntimeTest.java
@@ -31,8 +31,6 @@ import org.apache.maven.project.MavenProject;
 import org.arquillian.cube.CubeController;
 import org.arquillian.cube.HostIp;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
-import org.guvnor.ala.build.maven.model.MavenBinary;
-import org.guvnor.ala.build.maven.model.impl.MavenProjectBinaryImpl;
 import org.guvnor.ala.build.maven.model.impl.MavenProjectImpl;
 import org.guvnor.ala.build.maven.util.MavenBuildExecutor;
 import org.guvnor.ala.build.maven.util.RepositoryVisitor;
@@ -133,15 +131,10 @@ public class WildflyRuntimeTest {
         final File pom = new File( mavenProject.getTempDir(), "pom.xml" );
         MavenBuildExecutor.executeMaven( pom, properties, goals.toArray( new String[0] ) );
 
-        MavenBinary binary = new MavenProjectBinaryImpl( mavenProject );
+        final File file = new File(repositoryVisitor.getRoot().getAbsolutePath() + "/target/" + mavenProject.getExpectedBinary());
 
         WildflyClient wildflyClient = new WildflyClient( "", "admin", "Admin#70365", ip, 8080, 9990 );
-        String binaryPath = binary.getProject().getExpectedBinary();
 
-        String projectPath = repositoryVisitor.getRoot().getAbsolutePath();
-
-        String warPath = projectPath + "/target/" + binaryPath;
-        File file = new File( warPath );
         wildflyClient.deploy( file );
 
         final String id = file.getName();


### PR DESCRIPTION
 Add GAV attributes: artifactId, version and groupId to resolved MavenBinary.
 Resolve MavenBinary absolute path at the executor level, allowing reuse of both MavenBinaryImpl and MavenProjectBinaryImpl at Wildfly exec stage.