### PR TITLE
Add revapi plugin

### DIFF
--- a/guvnor-rest/guvnor-rest-backend/pom.xml
+++ b/guvnor-rest/guvnor-rest-backend/pom.xml
@@ -111,4 +111,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/guvnor-rest/guvnor-rest-backend/src/build/revapi-config.json
+++ b/guvnor-rest/guvnor-rest-backend/src/build/revapi-config.json
@@ -1,0 +1,24 @@
+{
+  "revapi": {
+    "java": {
+      "filter": {
+        "classes": {
+          "comment": "Just ProjectResource is checked",
+          "regex": false,
+          "include": [
+            "org.guvnor.rest.backend.ProjectResource"
+          ]
+        }
+      }
+    },
+    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+    "ignore": [
+      {
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String, org.guvnor.rest.client.BuildConfig)",
+        "new": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String)",
+        "justification": "BuildConfig parameter was unused"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi, @psiroky,

here is a revapi plugin for  guvnor-rest/guvnor-rest-backend module. It just checks REST endpoint called ProjectResource. There is again this bug in revapi, so 2 of 3 ignores are actually false-negatives.

Thanks,

Marian
