### PR TITLE
Use literal property names

### DIFF
--- a/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/preferences/GAVPreferences.java
+++ b/guvnor-project/guvnor-project-api/src/main/java/org/guvnor/common/services/project/preferences/GAVPreferences.java
@@ -39,12 +39,14 @@ public class GAVPreferences implements BasePreference<GAVPreferences> {
 
     @Override
     public GAVPreferences defaultValue( final GAVPreferences defaultValue ) {
-        final String conflictingGAVCheckDisabledSystemProperty = System.getProperty( CONFLICTING_GAV_CHECK_DISABLED, "false" );
+        //GWT complains in SuperDevMode if the static constants are used; so we have to use a literal
+        final String conflictingGAVCheckDisabledSystemProperty = System.getProperty( "org.guvnor.project.gav.check.disabled", "false" );
         final boolean conflictingGAVCheckDisabled = Boolean.parseBoolean( conflictingGAVCheckDisabledSystemProperty );
 
         defaultValue.setConflictingGAVCheckDisabled( conflictingGAVCheckDisabled );
 
-        final String childGAVEditEnabledSystemProperty = System.getProperty( CHILD_GAV_EDIT_ENABLED, "false" );
+        //GWT complains in SuperDevMode if the static constants are used; so we have to use a literal
+        final String childGAVEditEnabledSystemProperty = System.getProperty( "org.guvnor.project.gav.child.edit.enabled", "false" );
         final boolean childGAVEditEnabled = Boolean.parseBoolean( childGAVEditEnabledSystemProperty );
 
         defaultValue.setChildGAVEditEnabled( childGAVEditEnabled );


### PR DESCRIPTION
Fix GWT's SDM complaints about not using literals in ```System.getProperty(..)```

Further to https://github.com/droolsjbpm/guvnor/pull/394 SDM failed to compile with the error:
```
[ERROR] Errors in 'org/guvnor/common/services/project/preferences/GAVPreferences.java'
    [ERROR] Line 42: Only string constants may be used as property name in System.getProperty()
[ERROR] Errors in 'org/guvnor/common/services/project/preferences/GAVPreferences.java'
    [ERROR] Line 47: Only string constants may be used as property name in System.getProperty()
```
Reverting to using literals.