### PR TITLE
GUVNOR-2813: Not possible to copy repository URL in Repository Editor

### DIFF
--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorPresenter.java
@@ -18,9 +18,11 @@ package org.guvnor.structure.client.editors.repository.edit;
 
 import java.util.List;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.guvnor.structure.client.resources.i18n.CommonConstants;
 import org.guvnor.structure.client.security.RepositoryController;
 import org.guvnor.structure.repositories.PublicURI;
 import org.guvnor.structure.repositories.RepositoryInfo;
@@ -39,6 +41,7 @@ import org.uberfire.ext.widgets.core.client.resources.i18n.CoreConstants;
 import org.uberfire.java.nio.base.version.VersionRecord;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
 @WorkbenchScreen(identifier = "RepositoryEditor")
@@ -47,6 +50,7 @@ public class RepositoryEditorPresenter {
     private View view;
     private Caller<RepositoryService> repositoryService;
     private Caller<RepositoryServiceEditor> repositoryServiceEditor;
+    private Event<NotificationEvent> notification;
     private PlaceManager placeManager;
     private RepositoryController repositoryController;
 
@@ -76,11 +80,13 @@ public class RepositoryEditorPresenter {
     public RepositoryEditorPresenter( final View view,
                                       final Caller<RepositoryService> repositoryService,
                                       final Caller<RepositoryServiceEditor> repositoryServiceEditor,
+                                      final Event<NotificationEvent> notification,
                                       final PlaceManager placeManager,
                                       final RepositoryController repositoryController ) {
         this.view = view;
         this.repositoryService = repositoryService;
         this.repositoryServiceEditor = repositoryServiceEditor;
+        this.notification = notification;
         this.placeManager = placeManager;
         this.repositoryController = repositoryController;
     }
@@ -140,6 +146,10 @@ public class RepositoryEditorPresenter {
                            root,
                            comment,
                            record );
+    }
+
+    void onGitUrlCopied( final String uri ) {
+        notification.fire( new NotificationEvent( CommonConstants.INSTANCE.GitUriCopied( uri ) ) );
     }
 
     public void onRepositoryRemovedEvent( @Observes RepositoryRemovedEvent event ) {

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorView.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorView.java
@@ -77,9 +77,11 @@ public class RepositoryEditorView extends Composite
     private RepositoryEditorPresenter presenter;
     private boolean readOnly;
 
-    @PostConstruct
-    public void init() {
+    public RepositoryEditorView() {
         initWidget( uiBinder.createAndBindUi( this ) );
+
+        myGitCopyButton.addDomHandler( ( e ) -> presenter.onGitUrlCopied( gitDaemonURI.getText() ),
+                                       ClickEvent.getType() );
     }
 
     @Override
@@ -132,19 +134,19 @@ public class RepositoryEditorView extends Composite
             history.setVisible( false );
         }
 
-        loadMore.addClickHandler(new ClickHandler() {
+        loadMore.addClickHandler( new ClickHandler() {
             @Override
-            public void onClick(ClickEvent event) {
-                presenter.onLoadMoreHistory(history.getWidgetCount());
+            public void onClick( ClickEvent event ) {
+                presenter.onLoadMoreHistory( history.getWidgetCount() );
             }
-        });
+        } );
 
         final String uriId = "uri-for-" + repositoryName;
         gitDaemonURI.getElement().setId( uriId );
 
-        myGitCopyButton.init(false, uriId, gitDaemonURI.getText());
+        myGitCopyButton.init( false, uriId, gitDaemonURI.getText() );
 
-        glueCopy(myGitCopyButton.getElement());
+        glueCopy( myGitCopyButton.getElement() );
     }
 
     @Override

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemPresenter.java
@@ -18,25 +18,29 @@ package org.guvnor.structure.client.editors.repository.list;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.structure.client.editors.context.GuvnorStructureContext;
+import org.guvnor.structure.client.resources.i18n.CommonConstants;
 import org.guvnor.structure.client.security.RepositoryController;
 import org.guvnor.structure.repositories.PublicURI;
 import org.guvnor.structure.repositories.Repository;
 import org.uberfire.ext.widgets.core.client.resources.i18n.CoreConstants;
+import org.uberfire.workbench.events.NotificationEvent;
 
 public class RepositoryItemPresenter
         implements IsWidget {
 
     private Repository repository;
 
-    private RepositoryItemView     view;
+    private RepositoryItemView view;
     private GuvnorStructureContext guvnorStructureContext;
     private HasRemoveRepositoryHandlers removeRepositoryHandler;
     private RepositoryController repositoryController;
+    private Event<NotificationEvent> notification;
 
     public RepositoryItemPresenter() {
     }
@@ -44,10 +48,12 @@ public class RepositoryItemPresenter
     @Inject
     public RepositoryItemPresenter( final RepositoryItemView repositoryItemView,
                                     final GuvnorStructureContext guvnorStructureContext,
-                                    final RepositoryController repositoryController ) {
+                                    final RepositoryController repositoryController,
+                                    final Event<NotificationEvent> notification ) {
         this.view = repositoryItemView;
         this.guvnorStructureContext = guvnorStructureContext;
         this.repositoryController = repositoryController;
+        this.notification = notification;
     }
 
     public void setRepository( final Repository repository,
@@ -70,10 +76,10 @@ public class RepositoryItemPresenter
 
         populateBranches( branch );
 
-        boolean canUpdate = repositoryController.canUpdateRepository(repository);
-        boolean canDelete = repositoryController.canDeleteRepository(repository);
-        view.setUpdateEnabled(canUpdate);
-        view.setDeleteEnabled(canDelete);
+        boolean canUpdate = repositoryController.canUpdateRepository( repository );
+        boolean canDelete = repositoryController.canDeleteRepository( repository );
+        view.setUpdateEnabled( canUpdate );
+        view.setDeleteEnabled( canDelete );
 
         view.refresh();
     }
@@ -139,6 +145,10 @@ public class RepositoryItemPresenter
 
     public void addRemoveRepositoryCommand( final HasRemoveRepositoryHandlers removeRepositoryHandlers ) {
         this.removeRepositoryHandler = removeRepositoryHandlers;
+    }
+
+    void onGitUrlCopied( final String uri ) {
+        notification.fire( new NotificationEvent( CommonConstants.INSTANCE.GitUriCopied( uri ) ) );
     }
 
 }

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemViewImpl.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemViewImpl.java
@@ -71,6 +71,10 @@ public class RepositoryItemViewImpl
     @Inject
     public RepositoryItemViewImpl() {
         initWidget( uiBinder.createAndBindUi( this ) );
+
+        myGitCopyButton.addDomHandler( ( e ) -> presenter.onGitUrlCopied( gitDaemonURI.getText() ),
+                                       ClickEvent.getType() );
+
         glueCopy( myGitCopyButton.getElement() );
     }
 

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/resources/i18n/CommonConstants.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/resources/i18n/CommonConstants.java
@@ -65,4 +65,6 @@ public interface CommonConstants
 
     String Repositories();
 
+    String GitUriCopied(final String uri);
+
 }

--- a/guvnor-structure/guvnor-structure-client/src/main/resources/org/guvnor/structure/client/resources/i18n/CommonConstants.properties
+++ b/guvnor-structure/guvnor-structure-client/src/main/resources/org/guvnor/structure/client/resources/i18n/CommonConstants.properties
@@ -18,3 +18,4 @@ OrganizationalUnitActionDelete=Delete
 OrganizationalUnitActionCreate=Create
 Loading=Loading
 Repositories=Repositories
+GitUriCopied=Uri {0} has been successfully copied to the clipboard.

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorPresenterTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/edit/RepositoryEditorPresenterTest.java
@@ -37,8 +37,10 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.ext.widgets.core.client.resources.i18n.CoreConstants;
 import org.uberfire.java.nio.base.version.VersionRecord;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.mockito.Mockito.*;
 
@@ -55,6 +57,9 @@ public class RepositoryEditorPresenterTest {
 
     @Mock
     private RepositoryServiceEditor repositoryServiceEditor;
+
+    @Mock
+    private EventSourceMock<NotificationEvent> notification;
 
     @Mock
     private PlaceManager placeManager;
@@ -79,8 +84,9 @@ public class RepositoryEditorPresenterTest {
         presenter = new RepositoryEditorPresenter( view,
                                                    repositoryServiceCaller,
                                                    repositoryServiceEditorCaller,
+                                                   notification,
                                                    placeManager,
-                                                   repositoryController);
+                                                   repositoryController );
 
         repositoryInfo = new RepositoryInfo( "repository",
                                              "repository",
@@ -172,6 +178,14 @@ public class RepositoryEditorPresenterTest {
 
         verify( placeManager,
                 times( 1 ) ).closePlace( eq( place ) );
+    }
+
+    @Test
+    public void testNotificationFiredWhenGitUriCopied() {
+        presenter.onGitUrlCopied( "uri" );
+
+        verify( notification,
+                times( 1 ) ).fire( any( NotificationEvent.class ) );
     }
 
 }

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/list/RepositoriesPresenterTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/list/RepositoriesPresenterTest.java
@@ -35,6 +35,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -52,6 +54,9 @@ public class RepositoriesPresenterTest {
 
     @Mock
     private RepositoryController repositoryController;
+
+    @Mock
+    private EventSourceMock<NotificationEvent> notification;
 
     private GuvnorStructureContext guvnorStructureContext;
 
@@ -191,7 +196,7 @@ public class RepositoriesPresenterTest {
 
         //Emulates the context receiving the new branch event for a branch created in r1.
         guvnorStructureContext.onNewBranch( new NewBranchEvent( "r1",
-                "theNewBranch", branchPath, System.currentTimeMillis() ) );
+                                                                "theNewBranch", branchPath, System.currentTimeMillis() ) );
 
         //Verify that the view was properly populated including the new branch.
         //one time at initialization + one time when the new branch was loaded.
@@ -205,11 +210,14 @@ public class RepositoriesPresenterTest {
     }
 
     private RepositoryItemPresenter createItemPresenter( RepositoryItemView itemView,
-            GuvnorStructureContext guvnorStructureContext,
-            Repository repository,
-            String branch ) {
+                                                         GuvnorStructureContext guvnorStructureContext,
+                                                         Repository repository,
+                                                         String branch ) {
         //reproduces the initialization of the RepositoryItems performed by the view.
-        RepositoryItemPresenter itemPresenter = new RepositoryItemPresenter( itemView, guvnorStructureContext, repositoryController );
+        RepositoryItemPresenter itemPresenter = new RepositoryItemPresenter( itemView,
+                                                                             guvnorStructureContext,
+                                                                             repositoryController,
+                                                                             notification );
         itemPresenter.setRepository( repository, branch );
         return itemPresenter;
     }

--- a/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemPresenterTest.java
+++ b/guvnor-structure/guvnor-structure-client/src/test/java/org/guvnor/structure/client/editors/repository/list/RepositoryItemPresenterTest.java
@@ -29,6 +29,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.mockito.Mockito.*;
 
@@ -42,6 +44,9 @@ public class RepositoryItemPresenterTest {
     private RepositoryController repositoryController;
 
     @Mock
+    private EventSourceMock<NotificationEvent> notification;
+
+    @Mock
     private RepositoryItemView view;
 
     private RepositoryItemPresenter presenter;
@@ -49,9 +54,9 @@ public class RepositoryItemPresenterTest {
     @Mock
     private Repository repository;
 
-    List<PublicURI> publicURIs = new ArrayList<PublicURI>(  );
+    List<PublicURI> publicURIs = new ArrayList<PublicURI>();
 
-    List<String> branches = new ArrayList<String>(  );
+    List<String> branches = new ArrayList<String>();
 
     @Mock
     PublicURI uri1;
@@ -71,7 +76,10 @@ public class RepositoryItemPresenterTest {
         when( uri2.getProtocol() ).thenReturn( "test-protocol2" );
         when( uri2.getURI() ).thenReturn( "uri2" );
 
-        presenter = new RepositoryItemPresenter( view, guvnorStructureContext, repositoryController );
+        presenter = new RepositoryItemPresenter( view,
+                                                 guvnorStructureContext,
+                                                 repositoryController,
+                                                 notification );
         when( repository.getAlias() ).thenReturn( "TestRepo" );
 
         when( repositoryController.canUpdateRepository( repository ) ).thenReturn( false );
@@ -79,7 +87,7 @@ public class RepositoryItemPresenterTest {
     }
 
     @Test
-    public void repositoryWithPublicUrisAndBranchesLoadTest( ) {
+    public void repositoryWithPublicUrisAndBranchesLoadTest() {
         publicURIs.add( uri1 );
         publicURIs.add( uri2 );
         branches.add( "development" );
@@ -88,7 +96,7 @@ public class RepositoryItemPresenterTest {
     }
 
     @Test
-    public void repositoryWithPublicUrisAndNoBranchesLoadTest( ) {
+    public void repositoryWithPublicUrisAndNoBranchesLoadTest() {
         publicURIs.add( uri1 );
         publicURIs.add( uri2 );
         repositoryLoadTest( publicURIs, branches );
@@ -106,7 +114,8 @@ public class RepositoryItemPresenterTest {
         repositoryLoadTest( publicURIs, branches );
     }
 
-    private void repositoryLoadTest( List<PublicURI> uris, List<String> branches ) {
+    private void repositoryLoadTest( List<PublicURI> uris,
+                                     List<String> branches ) {
 
         when( repository.getAlias() ).thenReturn( "TestRepo" );
         when( repository.getPublicURIs() ).thenReturn( publicURIs );
@@ -148,7 +157,7 @@ public class RepositoryItemPresenterTest {
         branches.add( "release" );
 
         //emulates development branch was selected at the moment of the refresh
-        when( view.getSelectedBranch( ) ).thenReturn( "development" );
+        when( view.getSelectedBranch() ).thenReturn( "development" );
 
         //check that the repository was loaded properly
         repositoryLoadTest( publicURIs, branches );
@@ -169,4 +178,13 @@ public class RepositoryItemPresenterTest {
         //the previously selected branch should have been set again.
         verify( view, times( 1 ) ).setSelectedBranch( "development" );
     }
+
+    @Test
+    public void testNotificationFiredWhenGitUriCopied() {
+        presenter.onGitUrlCopied( "uri" );
+
+        verify( notification,
+                times( 1 ) ).fire( any( NotificationEvent.class ) );
+    }
+
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2813

This PR adds a "notification" for when the URI is copied. It does not address the use of Flash which is up for debate (see the original [JIRA](https://issues.jboss.org/browse/RHBPMS-4123) ).