### PR TITLE
Don't reference out-of-date playground repository in Guvnor ALA test.

### DIFF
--- a/guvnor-ala/guvnor-ala-build-maven/src/test/java/org/guvnor/ala/build/maven/executor/RepositoryVisitorTest.java
+++ b/guvnor-ala/guvnor-ala-build-maven/src/test/java/org/guvnor/ala/build/maven/executor/RepositoryVisitorTest.java
@@ -64,7 +64,7 @@ public class RepositoryVisitorTest {
     @Test
     public void repositoryVisitorDiffDeletedTest() throws IOException {
         final GitHub gitHub = new GitHub();
-        final GitRepository repository = ( GitRepository ) gitHub.getRepository( "salaboy/livespark-playground", new HashMap<String, String>() {
+        final GitRepository repository = ( GitRepository ) gitHub.getRepository( "mbarkley/appformer-playground", new HashMap<String, String>() {
             {
                 put( "out-dir", tempPath.getAbsolutePath() );
             }


### PR DESCRIPTION
So I noticed a test failure on master was caused by failure to download GWT 2.8.0-rc1. Though the error was probably due to network flakiness, we shouldn't be relying on that GWT version anywhere and I think the source was from this test using an outdated playground repo.

This change points the test to my fork of the appformer-playground which is currently being maintained. I also noticed several other tests pointing to Mauricio's forks of "drools-workshop" that we might need to update in the future.