### PR TITLE
Split revapi configuration into filter and ignores

### DIFF
--- a/guvnor-rest/guvnor-rest-backend/src/build/revapi-config.json
+++ b/guvnor-rest/guvnor-rest-backend/src/build/revapi-config.json
@@ -1,24 +1,31 @@
 {
-  "revapi": {
-    "java": {
-      "filter": {
-        "classes": {
-          "comment": "Just ProjectResource is checked",
-          "regex": false,
-          "include": [
-            "org.guvnor.rest.backend.ProjectResource"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "filter": {
+          "classes": {
+            "comment": "Just ProjectResource is checked",
+            "regex": false,
+            "include": [
+              "org.guvnor.rest.backend.ProjectResource"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String, org.guvnor.rest.client.BuildConfig)",
-        "new": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String)",
-        "justification": "BuildConfig parameter was unused"
-      }
-    ]
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String, org.guvnor.rest.client.BuildConfig)",
+          "new": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::testProject(java.lang.String, java.lang.String)",
+          "justification": "BuildConfig parameter was unused"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Hi,

this PR is related to droolsjbpm/droolsjbpm-build-bootstrap#393. Revapi config JSON file was divided into filter and ignores parts.

Marian
