### PR TITLE
JBPM-5714 - Extend  WildflyRuntimeExecConfig options customization via pipeline input

### DIFF
--- a/guvnor-ala/guvnor-ala-wildfly-provider/pom.xml
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/WildflyRuntimeConfiguration.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/WildflyRuntimeConfiguration.java
@@ -32,7 +32,7 @@ public interface WildflyRuntimeConfiguration extends ProvisioningConfig,
      * Get the War / App path
      * @return String with the path where the WAR (Web Archive) is located.
     */
-    String getWarPath();
+    default String getWarPath() { return "${input.war-path}"; }
     
     /*
      * Get the Redeploy Strategy for apps in wildfly
@@ -40,8 +40,6 @@ public interface WildflyRuntimeConfiguration extends ProvisioningConfig,
      *  - none: will fail if you try to redeploy an app that already exist
      * @return String with the strategy
     */
-    default String getRedeployStrategy(){
-        return "auto";
-    }
+    default String getRedeployStrategy() { return "${input.redeploy}"; }
 
 }

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/impl/ContextAwareWildflyRuntimeExecConfig.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/config/impl/ContextAwareWildflyRuntimeExecConfig.java
@@ -35,25 +35,31 @@ public class ContextAwareWildflyRuntimeExecConfig implements
     private Map<String, ?> context;
     private ProviderId providerId;
     private String warPath;
+    private String redeployStrategy;
 
     public ContextAwareWildflyRuntimeExecConfig() {
+        this.warPath = WildflyRuntimeExecConfig.super.getWarPath();
+        this.redeployStrategy = WildflyRuntimeExecConfig.super.getRedeployStrategy();
     }
 
     public ContextAwareWildflyRuntimeExecConfig( final ProviderId providerId,
-                                                 final String warPath ) {
+                                                 final String warPath,
+                                                 final String redeployStrategy) {
         this.providerId = providerId;
         this.warPath = warPath;
+        this.redeployStrategy = redeployStrategy;
     }
 
     @Override
     public void setContext( final Map<String, ?> context ) {
         this.context = context;
         MavenBinary binary = (MavenBinary) context.get( "binary" );
+        if (binary != null) {
+            this.warPath = binary.getPath().toString();
+        }
 
         WildflyProvider provider = (WildflyProvider) context.get( "wildfly-provider" );
         this.providerId = provider;
-        this.warPath = binary.getPath().toString();
-
     }
 
     @Override
@@ -67,8 +73,16 @@ public class ContextAwareWildflyRuntimeExecConfig implements
     }
 
     @Override
+    public String getRedeployStrategy() {
+        return redeployStrategy;
+    }
+
+    @Override
     public WildflyRuntimeExecConfig asNewClone( final WildflyRuntimeExecConfig origin ) {
-        return new ContextAwareWildflyRuntimeExecConfig( origin.getProviderId(),
-                                                         origin.getWarPath() );
+        return new ContextAwareWildflyRuntimeExecConfig(
+                origin.getProviderId(),
+                origin.getWarPath(),
+                origin.getRedeployStrategy()
+        );
     }
 }

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/executor/WildflyRuntimeExecExecutor.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/executor/WildflyRuntimeExecExecutor.java
@@ -3,12 +3,10 @@ package org.guvnor.ala.wildfly.executor;
 
 import java.io.File;
 import java.util.Optional;
-
 import javax.inject.Inject;
 
 import org.guvnor.ala.config.Config;
 import org.guvnor.ala.config.RuntimeConfig;
-
 import org.guvnor.ala.exceptions.ProvisioningException;
 import org.guvnor.ala.pipeline.FunctionConfigExecutor;
 import org.guvnor.ala.registry.RuntimeRegistry;
@@ -26,6 +24,8 @@ import org.guvnor.ala.wildfly.model.WildflyRuntimeInfo;
 import org.guvnor.ala.wildfly.model.WildflyRuntimeState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class WildflyRuntimeExecExecutor<T extends WildflyRuntimeConfiguration> implements RuntimeBuilder<T, WildflyRuntime>,
         RuntimeDestroyer,
@@ -61,13 +61,13 @@ public class WildflyRuntimeExecExecutor<T extends WildflyRuntimeConfiguration> i
         final String id = file.getName();
 
         WildflyAppState appState = wildfly.getWildflyClient( wildflyProvider ).getAppState( id );
-        if ( appState.getState().equals( "NA" ) ) {
+        if ("NA".equals(appState.getState())) {
             int result = wildfly.getWildflyClient( wildflyProvider ).deploy( file );
             if ( result != 200 ) {
                 throw new ProvisioningException( "Deployment to Wildfly Failed with error code: " + result );
             }
-        }else if(appState.getState().equals( "Running" ) 
-                && runtimeConfig.getRedeployStrategy().equals( "auto")){
+        } else if ("Running".equals(appState.getState()) &&
+                  (isNullOrEmpty(runtimeConfig.getRedeployStrategy()) || "auto".equals(runtimeConfig.getRedeployStrategy()))) {
             wildfly.getWildflyClient( wildflyProvider ).undeploy( id );
             int result = wildfly.getWildflyClient( wildflyProvider ).deploy( file );
             if ( result != 200 ) {

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/ContextAwareWildflyRuntimeExecConfigTest.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/ContextAwareWildflyRuntimeExecConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.ala.wildfly.executor.tests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.guvnor.ala.build.maven.model.MavenBinary;
+import org.guvnor.ala.wildfly.config.WildflyRuntimeExecConfig;
+import org.guvnor.ala.wildfly.config.impl.ContextAwareWildflyRuntimeExecConfig;
+import org.guvnor.ala.wildfly.model.WildflyProvider;
+import org.junit.Test;
+import org.uberfire.java.nio.file.Path;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.guvnor.ala.util.VariableInterpolation.interpolate;
+
+public class ContextAwareWildflyRuntimeExecConfigTest {
+
+    @Test
+    public void testDefaultExpression() {
+        assertEquals("${input.war-path}", new ContextAwareWildflyRuntimeExecConfig().getWarPath());
+    }
+
+    @Test
+    public void testContextUsingMavenBinary() {
+        final ContextAwareWildflyRuntimeExecConfig config = new ContextAwareWildflyRuntimeExecConfig();
+        final Map<String, Object> context = new HashMap<>();
+        final WildflyProvider provider = mock(WildflyProvider.class);
+        context.put("wildfly-provider", provider);
+        final MavenBinary binary = mock(MavenBinary.class);
+        final Path path = mock(Path.class);
+        when(binary.getPath()).thenReturn(path);
+        final String filePath = "/path/to/file.war";
+        when(path.toString()).thenReturn(filePath);
+        context.put("binary", binary);
+
+        config.setContext(context);
+
+        assertEquals(provider, config.getProviderId());
+        assertEquals(filePath, config.getWarPath());
+
+        final WildflyRuntimeExecConfig configClone = config.asNewClone(config);
+        assertEquals(provider, configClone.getProviderId());
+        assertEquals(filePath, configClone.getWarPath());
+    }
+
+    @Test
+    public void testContextUsingPath() {
+        final ContextAwareWildflyRuntimeExecConfig config = new ContextAwareWildflyRuntimeExecConfig();
+        final WildflyProvider provider = mock(WildflyProvider.class);
+        final Map<String, Object> context = singletonMap("wildfly-provider", provider);
+
+        config.setContext(context);
+
+        assertEquals(provider, config.getProviderId());
+        assertEquals("${input.war-path}", config.getWarPath());
+
+        final WildflyRuntimeExecConfig configClone = config.asNewClone(config);
+        assertEquals(provider, configClone.getProviderId());
+        assertEquals("${input.war-path}", configClone.getWarPath());
+    }
+
+    @Test
+    public void testVariablesResolution() {
+        final String filePath = "/path/to/file.war";
+        final String redeploy = "none";
+
+        Map<String, String> values = new HashMap<>();
+        values.put("war-path", filePath);
+        values.put("redeploy", redeploy);
+
+        final ContextAwareWildflyRuntimeExecConfig config = new ContextAwareWildflyRuntimeExecConfig();
+        final ContextAwareWildflyRuntimeExecConfig varConfig = interpolate(singletonMap("input", values), config);
+        assertEquals(filePath, varConfig.getWarPath());
+        assertEquals(redeploy, varConfig.getRedeployStrategy());
+    }
+
+}


### PR DESCRIPTION
Allow WildflyRuntimeExecConfig to consume either a maven binary or a path to the deployable file.
Allow redeploy strategy to be defined via input