### PR TITLE
Avoid NumberFormatException if optional Wildfly port not provided

### DIFF
--- a/guvnor-ala/guvnor-ala-wildfly-provider/pom.xml
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/pom.xml
@@ -78,6 +78,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/access/impl/WildflyAccessInterfaceImpl.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/main/java/org/guvnor/ala/wildfly/access/impl/WildflyAccessInterfaceImpl.java
@@ -26,6 +26,8 @@ import org.guvnor.ala.wildfly.model.WildflyProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
 public class WildflyAccessInterfaceImpl
         implements WildflyAccessInterface {
 
@@ -44,9 +46,14 @@ public class WildflyAccessInterfaceImpl
         assert ( providerId instanceof WildflyProvider );
         WildflyProvider wildflyProvider = ( ( WildflyProvider ) providerId );
 
-        return new WildflyClient( wildflyProvider.getId(),
-                wildflyProvider.getUser(), wildflyProvider.getPassword(),
-                wildflyProvider.getHostId(), Integer.valueOf( wildflyProvider.getPort() ), Integer.valueOf( wildflyProvider.getManagementPort() ) );
+        return new WildflyClient(
+                wildflyProvider.getId(),
+                wildflyProvider.getUser(),
+                wildflyProvider.getPassword(),
+                wildflyProvider.getHostId(),
+                Integer.valueOf(defaultIfBlank(wildflyProvider.getPort(), "8080")),
+                Integer.valueOf(defaultIfBlank(wildflyProvider.getManagementPort(), "9990"))
+        );
     }
 
     @Override

--- a/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/WildflyAccessInterfaceImplTest.java
+++ b/guvnor-ala/guvnor-ala-wildfly-provider/src/test/java/org/guvnor/ala/wildfly/executor/tests/WildflyAccessInterfaceImplTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.ala.wildfly.executor.tests;
+
+import org.guvnor.ala.wildfly.access.WildflyClient;
+import org.guvnor.ala.wildfly.access.impl.WildflyAccessInterfaceImpl;
+import org.guvnor.ala.wildfly.model.WildflyProviderImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WildflyAccessInterfaceImplTest {
+
+    private WildflyAccessInterfaceImpl accessInterface = new WildflyAccessInterfaceImpl();
+
+    private static final String PROVIDER = "wildfly";
+
+    @Test
+    public void testWildflyClientNull() {
+        final WildflyClient client = accessInterface.getWildflyClient(new WildflyProviderImpl(PROVIDER, null, null, null, null, null));
+
+        assertNotNull(client);
+        assertEquals(client.getPort(), 8080);
+        assertEquals(client.getManagementPort(), 9990);
+    }
+
+    @Test
+    public void testWildflyClient() {
+        final String hostId = "localhost";
+        final String port = "8081";
+        final String managementPort = "9991";
+        final String user = "admin";
+        final String password = "pass";
+
+        final WildflyClient client = accessInterface.getWildflyClient(new WildflyProviderImpl(PROVIDER, hostId, port, managementPort, user, password));
+
+        assertNotNull(client);
+        assertEquals(client.getPort(), 8081);
+        assertEquals(client.getManagementPort(), 9991);
+        assertEquals(client.getHost(), hostId);
+        assertEquals(client.getProviderName(), PROVIDER);
+        assertEquals(client.getUser(), user);
+        assertEquals(client.getPassword(), password);
+    }
+
+}


### PR DESCRIPTION
Use default for port (8080) and management (9990) port if not provided.