### PR TITLE
PLANNER-704: Workbench: scoreHolder global can only be of org.optaplanner.core.api.score.holder.ScoreHolder type (or subclass)

### DIFF
--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/Metadata.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/Metadata.java
@@ -55,6 +55,8 @@ public class Metadata {
     private List<DiscussionRecord> discussion = new ArrayList<DiscussionRecord>();
     private List<VersionRecord>    version    = new ArrayList<VersionRecord>();
 
+    private boolean generated;
+
     public Metadata() {
 
     }
@@ -74,7 +76,8 @@ public class Metadata {
                      final List<String> tags,
                      final List<DiscussionRecord> discussion,
                      final List<VersionRecord> version,
-                     final LockInfo lockInfo) {
+                     final LockInfo lockInfo,
+                     final boolean generated ) {
         this.path = path;
         this.realPath = realPath;
         this.checkinComment = checkinComment;
@@ -91,6 +94,7 @@ public class Metadata {
         this.discussion = discussion;
         this.version = version;
         this.lockInfo = lockInfo;
+        this.generated = generated;
     }
 
     public Path getPath() {
@@ -156,7 +160,11 @@ public class Metadata {
     public LockInfo getLockInfo() {
         return lockInfo;
     }
-    
+
+    public boolean isGenerated() {
+        return generated;
+    }
+
     public void setLockInfo( LockInfo lockInfo ) {
         this.lockInfo = lockInfo;
     }
@@ -256,6 +264,9 @@ public class Metadata {
         if ( lockInfo != null ? !lockInfo.equals( metadata.lockInfo ) : metadata.lockInfo != null ) {
             return false;
         }
+        if ( generated != metadata.generated ) {
+            return false;
+        }
 
         return true;
     }
@@ -291,6 +302,10 @@ public class Metadata {
         result = 31 * result + ( discussion != null ? discussion.hashCode() : 0 );
         result = ~~result;
         result = 31 * result + ( version != null ? version.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( lockInfo != null ? lockInfo.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( generated ? 1 : 0 );
         result = ~~result;
         return result;
     }

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataBuilder.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataBuilder.java
@@ -58,6 +58,8 @@ public final class MetadataBuilder {
     private List<DiscussionRecord> discussion = new ArrayList<DiscussionRecord>();
     private List<VersionRecord> version = new ArrayList<VersionRecord>();
 
+    private boolean generated;
+
     private MetadataBuilder() {
 
     }
@@ -145,6 +147,11 @@ public final class MetadataBuilder {
         this.lockInfo = lockInfo;
         return this;
     }
+
+    public MetadataBuilder withGenerated( final boolean generated ) {
+        this.generated = generated;
+        return this;
+    }
     
     public Metadata build() {
         return new Metadata( path,
@@ -162,7 +169,8 @@ public final class MetadataBuilder {
                              tags,
                              discussion,
                              version,
-                             lockInfo );
+                             lockInfo,
+                             generated );
     }
 
 }

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataCreator.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataCreator.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
 import org.guvnor.common.services.shared.metadata.model.DiscussionRecord;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
@@ -47,6 +48,7 @@ public class MetadataCreator {
     private final DiscussionView discussView;
     private final OtherMetaView otherMetaView;
     private final VersionAttributeView versionAttributeView;
+    private final GeneratedAttributesView generatedAttributesView;
     private final IOService configIOService;
     private final SessionInfo sessionInfo;
 
@@ -56,7 +58,8 @@ public class MetadataCreator {
                             DublinCoreView dublinCoreView,
                             DiscussionView discussionView,
                             OtherMetaView otherMetaView,
-                            VersionAttributeView versionAttributeView ) {
+                            VersionAttributeView versionAttributeView,
+                            GeneratedAttributesView generatedAttributesView ) {
         this.path = checkNotNull( "path", path );
         this.configIOService = checkNotNull( "configIOService", configIOService );
         this.sessionInfo = checkNotNull( "sessionInfo", sessionInfo );
@@ -64,6 +67,7 @@ public class MetadataCreator {
         this.discussView = checkNotNull( "discussionView", discussionView );
         this.otherMetaView = checkNotNull( "otherMetaView", otherMetaView );
         this.versionAttributeView = checkNotNull( "versionAttributeView", versionAttributeView );
+        this.generatedAttributesView = checkNotNull( "generatedAttributesView", generatedAttributesView );
     }
 
     public Metadata create() {
@@ -84,6 +88,7 @@ public class MetadataCreator {
                 .withDiscussion( getDiscussion() )
                 .withLockInfo( retrieveLockInfo( Paths.convert( path ) ) )
                 .withVersion( getVersion() )
+                .withGenerated( getGenerated() )
                 .build();
     }
 
@@ -93,6 +98,10 @@ public class MetadataCreator {
                 add( new PortableVersionRecord( record.id(), record.author(), record.email(), record.comment(), record.date(), record.uri() ) );
             }
         }};
+    }
+
+    private boolean getGenerated() {
+        return generatedAttributesView.readAttributes().isGenerated();
     }
 
     private List<DiscussionRecord> getDiscussion() {

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
@@ -29,6 +29,7 @@ import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
@@ -86,7 +87,8 @@ public class MetadataServiceImpl
                                         ioService.getFileAttributeView( path, DublinCoreView.class ),
                                         ioService.getFileAttributeView( path, DiscussionView.class ),
                                         ioService.getFileAttributeView( path, OtherMetaView.class ),
-                                        ioService.getFileAttributeView( path, VersionAttributeView.class ) ).create();
+                                        ioService.getFileAttributeView( path, VersionAttributeView.class ),
+                                        ioService.getFileAttributeView( path, GeneratedAttributesView.class ) ).create();
 
         } catch ( Exception e ) {
             throw ExceptionUtilities.handleException( e );
@@ -359,6 +361,8 @@ public class MetadataServiceImpl
                             return null;
                         }
                     }, "*" ) );
+
+            attrs.put( GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME, metadata.isGenerated() );
 
             return attrs;
 

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.Map;
+
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.base.AbstractBasicFileAttributeView;
+import org.uberfire.java.nio.base.AbstractPath;
+import org.uberfire.java.nio.base.NeedsPreloadedAttrs;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.file.attribute.FileTime;
+
+public class GeneratedAttributesView extends AbstractBasicFileAttributeView<AbstractPath> implements NeedsPreloadedAttrs {
+
+    public static final String GENERATED_VIEW_NAME = "generated";
+
+    public static final String GENERATED_ATTRIBUTE_NAME = GENERATED_VIEW_NAME + ".generated";
+
+    private GeneratedFileAttributes generatedFileAttributes;
+
+    public GeneratedAttributesView( AbstractPath path ) {
+        super( path );
+
+        final boolean generated = extractGenerated();
+
+        final BasicFileAttributes fileAttrs = path.getFileSystem().provider().getFileAttributeView( path,
+                                                                                                    BasicFileAttributeView.class ).readAttributes();
+
+        this.generatedFileAttributes = new GeneratedFileAttributes() {
+            @Override
+            public boolean isGenerated() {
+                return generated;
+            }
+
+            @Override
+            public FileTime lastModifiedTime() {
+                return fileAttrs.lastModifiedTime();
+            }
+
+            @Override
+            public FileTime lastAccessTime() {
+                return fileAttrs.lastAccessTime();
+            }
+
+            @Override
+            public FileTime creationTime() {
+                return fileAttrs.creationTime();
+            }
+
+            @Override
+            public boolean isRegularFile() {
+                return fileAttrs.isRegularFile();
+            }
+
+            @Override
+            public boolean isDirectory() {
+                return fileAttrs.isDirectory();
+            }
+
+            @Override
+            public boolean isSymbolicLink() {
+                return fileAttrs.isSymbolicLink();
+            }
+
+            @Override
+            public boolean isOther() {
+                return fileAttrs.isOther();
+            }
+
+            @Override
+            public long size() {
+                return fileAttrs.size();
+            }
+
+            @Override
+            public Object fileKey() {
+                return fileAttrs.fileKey();
+            }
+        };
+    }
+
+    private boolean extractGenerated() {
+        final Map<String, Object> content = path.getAttrStorage().getContent();
+
+        return Boolean.parseBoolean( String.valueOf( content.get( GENERATED_ATTRIBUTE_NAME ) ) );
+    }
+
+    @Override
+    public String name() {
+        return GENERATED_VIEW_NAME;
+    }
+
+    @Override
+    public Class[] viewTypes() {
+        return new Class[]{ GeneratedAttributesView.class };
+    }
+
+    @Override
+    public GeneratedFileAttributes readAttributes() throws IOException {
+        return generatedFileAttributes;
+    }
+}

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributes.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributes.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * Represents attributes of a file which has been generated.
+ */
+public interface GeneratedFileAttributes extends BasicFileAttributes {
+
+    boolean isGenerated();
+}

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataCreatorTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/MetadataCreatorTest.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedFileAttributes;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.junit.Before;
@@ -65,6 +67,10 @@ public class MetadataCreatorTest {
     private OtherMetaView otherMetaView;
     @Mock
     private VersionAttributeView versionAttributeView;
+    @Mock
+    private GeneratedFileAttributes generatedFileAttributes;
+    @Mock
+    private GeneratedAttributesView generatedAttributesView;
 
     private MetadataCreator service;
     private Path mainFilePath;
@@ -82,6 +88,7 @@ public class MetadataCreatorTest {
         when( dcoreView.readAttributes() ).thenReturn( new DublinCoreAttributesMock() );
         when( otherMetaView.readAttributes() ).thenReturn( new OtherMetaAttributesMock() );
         when( discussView.readAttributes() ).thenReturn( new DiscussionAttributesMock() );
+        when( generatedAttributesView.readAttributes() ).thenReturn( generatedFileAttributes );
 
         fileSystemProvider = new SimpleFileSystemProvider();
 
@@ -96,7 +103,8 @@ public class MetadataCreatorTest {
                                        dcoreView,
                                        discussView,
                                        otherMetaView,
-                                       versionAttributeView );
+                                       versionAttributeView,
+                                       generatedAttributesView );
     }
 
     @Test
@@ -107,6 +115,16 @@ public class MetadataCreatorTest {
         assertNotNull( metadata.getTags() );
         assertNotNull( metadata.getDiscussion() );
         assertNotNull( metadata.getVersion() );
+    }
+
+    @Test
+    public void testGeneratedAttributes() {
+        when( generatedFileAttributes.isGenerated() ).thenReturn( true );
+        when( generatedAttributesView.readAttributes() ).thenReturn( generatedFileAttributes );
+
+        Metadata metadata = service.create();
+
+        assertTrue( metadata.isGenerated() );
     }
 
     @Test

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributesViewTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributesViewTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.base.AbstractPath;
+import org.uberfire.java.nio.base.AttrsStorage;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneratedFileAttributesViewTest {
+
+    @Test
+    public void readAttributesGeneratedFile() {
+        readAttributesTest( true );
+    }
+
+    @Test
+    public void readAttributesNonGeneratedFile() {
+        readAttributesTest( false );
+    }
+
+    private void readAttributesTest( final boolean generated ) {
+        AttrsStorage attrsStorage = mock( AttrsStorage.class );
+        when( attrsStorage.getContent() ).thenReturn( new HashMap<String, Object>() {{
+            put( GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                 generated );
+        }} );
+        AbstractPath path = mock( AbstractPath.class );
+        when( path.getAttrStorage() ).thenReturn( attrsStorage );
+
+        FileSystemProvider fileSystemProvider = mock( FileSystemProvider.class );
+        BasicFileAttributeView basicFileAttributeView = mock( BasicFileAttributeView.class );
+        when( basicFileAttributeView.readAttributes() ).thenReturn( mock( BasicFileAttributes.class ) );
+        when( fileSystemProvider.getFileAttributeView( any(),
+                                                       any() ) ).thenReturn( basicFileAttributeView );
+        FileSystem fileSystem = mock( FileSystem.class );
+        when( fileSystem.provider() ).thenReturn( fileSystemProvider );
+        when( path.getFileSystem() ).thenReturn( fileSystem );
+
+        GeneratedAttributesView view = new GeneratedAttributesView( path );
+
+        GeneratedFileAttributes generatedFileAttributes = view.readAttributes();
+
+        assertEquals( generated,
+                      generatedFileAttributes.isGenerated() );
+    }
+}


### PR DESCRIPTION
* Introduce GeneratedFileAttributesView

Useful to mark a file as "generated" and react accordingly on its processing. The file can be generated as a consequence of an action (e.g. creating a Planning Solution in OptaPlanner domain editor, etc.).

Part of:
https://github.com/droolsjbpm/guvnor/pull/421
https://github.com/droolsjbpm/drools-wb/pull/413
https://github.com/droolsjbpm/optaplanner-wb/pull/138 